### PR TITLE
fix(#4): correct go install command in README

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,10 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Editor-based HTTP Client requests
+/httpRequests/
+# Ignored default folder with query files
+/queries/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ It builds a compact graph of packages, symbols, calls, routes, config reads, tes
 brew install ozgurcd/tap/gograph
 
 # Or using Go:
-go install github.com/ozgurcd/gograph@latest
+go install github.com/ozgurcd/gograph/cmd/gograph@latest
 ```
 
 ## Usage


### PR DESCRIPTION
## Description
Updated README for correct `go install` command.

Fixes #4 

## Type of change
- Documentation only (README) - No code changes

## Checklist:
N/A - Docs-only change