### PR TITLE
fix(cli): reject --json combined with --mermaid

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -87,6 +87,15 @@ func Run(args []string) int {
 	}
 	args = filtered
 
+	// --json and --mermaid are mutually exclusive: --json emits a single
+	// {"ok":true,...} envelope, --mermaid emits a Mermaid diagram. Asking
+	// for both would silently produce whichever the consumer code reaches
+	// last, which is surprising and breaks piping.
+	if jsonMode && mermaidMode {
+		fmt.Fprintln(os.Stderr, "Error: --json and --mermaid cannot be combined")
+		return 1
+	}
+
 	// Bare `gograph --mermaid` (no subcommand) → architecture overview diagram.
 	if len(args) == 0 {
 		if mermaidMode {


### PR DESCRIPTION
fix(cli): reject --json combined with --mermaid

`--json` emits a single `{"ok":true,...}` JSON envelope and `--mermaid`
emits a Mermaid diagram. The flag-parsing loop in `internal/cli/cli.go`
set each flag independently, so passing both was accepted: the
downstream code paths then raced for output shape, with whichever the
consumer reached last silently winning. This broke piping and gave
surprising results to anyone who tried `gograph ... --json --mermaid`
or `--mermaid --json`.

After the flag scan, if both are set, print a one-line error to stderr
and exit 1 instead of letting the request through. The error message
names both flags so a user can re-run with the right one.
