### PR TITLE
feat: add HttpCallEdge extraction for net/http client calls

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -673,6 +673,7 @@ func BuildGraph(absRoot string) (*graph.Graph, error) {
 		g.TestEdges = append(g.TestEdges, result.TestEdges...)
 		g.Mutations = append(g.Mutations, result.Mutations...)
 		g.Literals = append(g.Literals, result.Literals...)
+		g.HttpCalls = append(g.HttpCalls, result.HttpCalls...)
 
 		if _, ok := pkgMap[dir]; !ok {
 			pkgMap[dir] = &graph.PackageNode{

--- a/internal/graph/graph.go
+++ b/internal/graph/graph.go
@@ -30,6 +30,7 @@ type Graph struct {
 	Implements   []ImplementsEdge  `json:"implements,omitempty"`
 	Mutations    []MutationEdge    `json:"mutations,omitempty"`
 	Literals     []LiteralEdge     `json:"literals,omitempty"`
+	HttpCalls    []HttpCallEdge    `json:"http_calls,omitempty"`
 	Baseline     *GraphBaseline    `json:"baseline,omitempty"`
 }
 
@@ -74,6 +75,17 @@ type LiteralEdge struct {
 	Function string `json:"function"`
 	File     string `json:"file"`
 	Line     int    `json:"line"`
+}
+
+// HttpCallEdge represents a detected HTTP client call (net/http).
+type HttpCallEdge struct {
+	SourceFile     string   `json:"sourceFile"`
+	SourceLine     int      `json:"sourceLine"`
+	FunctionName   string   `json:"functionName"`
+	Method         string   `json:"method"`
+	URL            string   `json:"url"`
+	StaticSegments []string `json:"staticSegments"`
+	HasDynamic     bool     `json:"hasDynamic"`
 }
 
 // ImplementsEdge records absolute proof that a concrete type implements an interface.

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -10,6 +10,7 @@ import (
 	"go/parser"
 	"go/printer"
 	"go/token"
+	"net/url"
 	"strings"
 
 	"github.com/ozgurcd/gograph/internal/graph"
@@ -29,6 +30,7 @@ type FileResult struct {
 	TestEdges   []graph.TestEdge
 	Mutations   []graph.MutationEdge
 	Literals    []graph.LiteralEdge
+	HttpCalls   []graph.HttpCallEdge
 }
 
 // ParseFile parses a single .go file and extracts its nodes.
@@ -546,6 +548,38 @@ func extractFuncDecl(fset *token.FileSet, d *ast.FuncDecl, relPath, pkgName, pkg
 						break
 					}
 				}
+			}
+
+			// HTTP Client Call Extraction
+			if method, ok := extractHTTPMethod(callee, call); ok && len(call.Args) >= 1 {
+				urlExpr := call.Args[0]
+				var urlStr string
+				hasDynamic := true
+
+				if lit, ok2 := urlExpr.(*ast.BasicLit); ok2 && lit.Kind == token.STRING {
+					urlStr = strings.Trim(lit.Value, "\"")
+					hasDynamic = false
+				} else {
+					urlStr = exprName(urlExpr)
+					if urlStr == "" {
+						urlStr = "<dynamic>"
+					}
+				}
+
+				var staticSegments []string
+				if !hasDynamic {
+					staticSegments = extractStaticSegments(urlStr)
+				}
+
+				result.HttpCalls = append(result.HttpCalls, graph.HttpCallEdge{
+					SourceFile:     relPath,
+					SourceLine:     callPos.Line,
+					FunctionName:   callerName,
+					Method:         method,
+					URL:            urlStr,
+					StaticSegments: staticSegments,
+					HasDynamic:     hasDynamic,
+				})
 			}
 
 			// Test edge: record which production symbols a test calls.
@@ -1112,6 +1146,52 @@ func envRead(call *ast.CallExpr, callee string, line int, file, fn string) (grap
 		Line:     line,
 		Function: fn,
 	}, true
+}
+
+// extractHTTPMethod checks whether a call expression is an HTTP client call
+// and returns the HTTP method (GET, POST, etc.) if so.
+func extractHTTPMethod(callee string, call *ast.CallExpr) (string, bool) {
+	switch callee {
+	case "http.Get":
+		return "GET", true
+	case "http.Post":
+		return "POST", true
+	case "http.PostForm":
+		return "POST", true
+	case "http.Head":
+		return "HEAD", true
+	}
+	// Check for *http.Client method calls by method name suffix.
+	sel, ok := call.Fun.(*ast.SelectorExpr)
+	if !ok {
+		return "", false
+	}
+	switch sel.Sel.Name {
+	case "Get":
+		return "GET", true
+	case "Post":
+		return "POST", true
+	case "PostForm":
+		return "POST", true
+	case "Head":
+		return "HEAD", true
+	case "Do":
+		return "GET", true
+	}
+	return "", false
+}
+
+// extractStaticSegments parses a URL string and returns non-empty path segments.
+func extractStaticSegments(rawURL string) []string {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return nil
+	}
+	path := strings.Trim(u.Path, "/")
+	if path == "" {
+		return nil
+	}
+	return strings.Split(path, "/")
 }
 
 func resolveStringLiteral(body *ast.BlockStmt, identName string) (string, bool) {

--- a/internal/parser/parser_httpclient_test.go
+++ b/internal/parser/parser_httpclient_test.go
@@ -1,0 +1,140 @@
+package parser_test
+
+import (
+	"go/token"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/ozgurcd/gograph/internal/parser"
+)
+
+func httpClientDir() string {
+	_, file, _, _ := runtime.Caller(0)
+	return filepath.Join(filepath.Dir(file), "testdata", "httpclient")
+}
+
+func TestParseFile_HTTPClientCalls(t *testing.T) {
+	fset := token.NewFileSet()
+	fixturePath := filepath.Join(httpClientDir(), "httpclient.go")
+	result, err := parser.ParseFile(fset, fixturePath, "httpclient/httpclient.go", "example.com/httpclient")
+	if err != nil {
+		t.Fatalf("ParseFile returned error: %v", err)
+	}
+
+	t.Run("http.Get with static URL", func(t *testing.T) {
+		found := false
+		for _, h := range result.HttpCalls {
+			if h.Method == "GET" && h.URL == "https://api.example.com/users" && !h.HasDynamic {
+				found = true
+				if len(h.StaticSegments) != 1 || h.StaticSegments[0] != "users" {
+					t.Errorf("unexpected static segments: %v", h.StaticSegments)
+				}
+			}
+		}
+		if !found {
+			t.Error("expected http.Get call to https://api.example.com/users")
+		}
+	})
+
+	t.Run("http.Post with static URL", func(t *testing.T) {
+		found := false
+		for _, h := range result.HttpCalls {
+			if h.Method == "POST" && h.URL == "https://api.example.com/users" && !h.HasDynamic {
+				found = true
+			}
+		}
+		if !found {
+			t.Error("expected http.Post call")
+		}
+	})
+
+	t.Run("http.PostForm with static URL", func(t *testing.T) {
+		found := false
+		for _, h := range result.HttpCalls {
+			if h.Method == "POST" && h.URL == "https://api.example.com/login" && !h.HasDynamic {
+				found = true
+			}
+		}
+		if !found {
+			t.Error("expected http.PostForm call")
+		}
+	})
+
+	t.Run("http.Head with static URL", func(t *testing.T) {
+		found := false
+		for _, h := range result.HttpCalls {
+			if h.Method == "HEAD" && h.URL == "https://api.example.com/health" && !h.HasDynamic {
+				found = true
+			}
+		}
+		if !found {
+			t.Error("expected http.Head call")
+		}
+	})
+
+	t.Run("client.Get with dynamic URL", func(t *testing.T) {
+		found := false
+		for _, h := range result.HttpCalls {
+			if h.Method == "GET" && h.URL == "url" && h.HasDynamic && h.FunctionName == "dynamicURL" {
+				found = true
+			}
+		}
+		if !found {
+			t.Error("expected client.Get call in dynamicURL")
+		}
+	})
+
+	t.Run("client.Get with concatenated URL", func(t *testing.T) {
+		found := false
+		for _, h := range result.HttpCalls {
+			if h.Method == "GET" && h.FunctionName == "getUser" {
+				found = true
+			}
+		}
+		if !found {
+			t.Error("expected client.Get call in getUser")
+		}
+	})
+
+	t.Run("multi-segment static URL", func(t *testing.T) {
+		found := false
+		for _, h := range result.HttpCalls {
+			if h.Method == "GET" && h.URL == "https://user-svc/api/v2/users" && !h.HasDynamic {
+				found = true
+				if len(h.StaticSegments) != 3 || h.StaticSegments[0] != "api" || h.StaticSegments[1] != "v2" || h.StaticSegments[2] != "users" {
+					t.Errorf("unexpected static segments for multi-segment URL: %v", h.StaticSegments)
+				}
+			}
+		}
+		if !found {
+			t.Error("expected http.Get call to https://user-svc/api/v2/users")
+		}
+	})
+
+	t.Run("client.Do detected", func(t *testing.T) {
+		found := false
+		for _, h := range result.HttpCalls {
+			if h.FunctionName == "doRequest" && h.Method == "GET" {
+				found = true
+			}
+		}
+		if !found {
+			t.Error("expected client.Do call in doRequest")
+		}
+	})
+
+	t.Run("function name populated", func(t *testing.T) {
+		for _, h := range result.HttpCalls {
+			if h.FunctionName == "" {
+				t.Error("expected non-empty FunctionName")
+			}
+			if h.SourceLine == 0 {
+				t.Error("expected non-zero SourceLine")
+			}
+			if h.SourceFile == "" {
+				t.Error("expected non-empty SourceFile")
+			}
+		}
+	})
+}

--- a/internal/parser/testdata/httpclient/httpclient.go
+++ b/internal/parser/testdata/httpclient/httpclient.go
@@ -1,0 +1,44 @@
+package httpclient
+
+import (
+	"net/http"
+)
+
+var globalClient = &http.Client{}
+
+func fetchUsers() {
+	resp, err := http.Get("https://api.example.com/users")
+	if err != nil {
+		panic(err)
+	}
+	defer resp.Body.Close()
+}
+
+func getUser(id string) {
+	globalClient.Get("https://api.example.com/users/" + id)
+}
+
+func createUser() {
+	resp, _ := http.Post("https://api.example.com/users", "application/json", nil)
+	defer resp.Body.Close()
+}
+
+func login() {
+	http.PostForm("https://api.example.com/login", nil)
+}
+
+func healthCheck() {
+	http.Head("https://api.example.com/health")
+}
+
+func dynamicURL(url string) {
+	globalClient.Get(url)
+}
+
+func multiSegment() {
+	http.Get("https://user-svc/api/v2/users")
+}
+
+func doRequest(req *http.Request) {
+	globalClient.Do(req)
+}


### PR DESCRIPTION
### What

Adds `HttpCallEdge` — a new edge type that detects outbound HTTP client calls made via `net/http`. This completes the HTTP story in gograph alongside existing server-side router extraction (Gin, Echo, Chi, net/http handlers).

### What gets extracted

| Pattern | Example | Extracted |
|---|---|---|
| Package-level | `http.Get(...)` | Method=GET, URL=literal |
| `*http.Client` methods | `client.Post(...)` | Method=POST, URL=literal |
| Client.Do | `client.Do(req)` | Method=GET, URL=<dynamic> |
| Dynamic URLs | `client.Get(urlVar)` | `hasDynamic: true` |
| Static path segments | `https://svc/api/v2/users` | `["api", "v2", "users"]` |

### Why

gograph's output is designed for AI coding agents to understand Go codebases without running code. Knowing which external APIs a service calls — and which functions make those calls — is essential for impact analysis, dependency mapping, and answering questions like "What happens if this endpoint changes?" The structured JSON format (method, url, staticSegments, hasDynamic) makes this trivially queryable by LLMs.

### Implementation

- AST-only extraction in `extractFuncDecl` — no runtime, no SSA, consistent with gograph's design
- Handles both `http.Func(...)` and `(*http.Client).Method(...)` forms
- Static URLs parsed into path segments via `url.Parse`
- ~140 lines of tests covering all standard methods, dynamic URLs, `client.Do`, and multi-segment paths
- Non-invasive — new edge type `HttpCallEdge` in the graph, no changes to existing extraction
