### PR TITLE
feat: add HTTPCallEdge extraction, CLI command, and MCP tool

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -673,7 +673,7 @@ func BuildGraph(absRoot string) (*graph.Graph, error) {
 		g.TestEdges = append(g.TestEdges, result.TestEdges...)
 		g.Mutations = append(g.Mutations, result.Mutations...)
 		g.Literals = append(g.Literals, result.Literals...)
-		g.HttpCalls = append(g.HttpCalls, result.HttpCalls...)
+		g.HTTPCalls = append(g.HTTPCalls, result.HTTPCalls...)
 
 		if _, ok := pkgMap[dir]; !ok {
 			pkgMap[dir] = &graph.PackageNode{

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -673,6 +673,7 @@ func BuildGraph(absRoot string) (*graph.Graph, error) {
 		g.TestEdges = append(g.TestEdges, result.TestEdges...)
 		g.Mutations = append(g.Mutations, result.Mutations...)
 		g.Literals = append(g.Literals, result.Literals...)
+		g.HttpCalls = append(g.HttpCalls, result.HttpCalls...)
 
 		if _, ok := pkgMap[dir]; !ok {
 			pkgMap[dir] = &graph.PackageNode{

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -292,6 +292,8 @@ func dispatch(args []string) int {
 		return 0
 	case "hook-guard":
 		return runHookGuard()
+	case "httpcalls":
+		return runHTTPCalls(args[1:])
 	case "help", "--help", "-h":
 		printHelp()
 		return 0
@@ -2322,6 +2324,21 @@ func runErrors(args []string) int {
 	}
 	results := search.Errors(g, term, includeTests)
 	return printResults("errors", term, results, "No custom errors or panics found.")
+}
+
+// runHTTPCalls lists all detected HTTP client calls in the graph.
+func runHTTPCalls(args []string) int {
+	term := ""
+	if len(args) > 0 {
+		term = args[0]
+	}
+	g, err := loadGraph(".")
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return 1
+	}
+	results := search.HTTPCalls(g, term)
+	return printResults("httpcalls", term, results, "No HTTP client calls found.")
 }
 
 // runSkeleton prints a stripped skeleton of the repository structure.

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -91,6 +91,7 @@ func TestAllCommandsRegistered(t *testing.T) {
 		"coupling",
 		"context",
 		"hotspot",
+		"httpcalls",
 		"deps",
 		"dependents",
 		"changes",

--- a/internal/cli/e2e_test.go
+++ b/internal/cli/e2e_test.go
@@ -154,3 +154,174 @@ func main() {
 		t.Errorf("expected JSON success status, got: %s", outJSON)
 	}
 }
+
+// TestE2E_HTTPCalls verifies the full httpcalls pipeline: build a Go project
+// with HTTP client calls, then query them via the CLI command.
+func TestE2E_HTTPCalls(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Write a minimal Go module with HTTP client calls.
+	mainGo := filepath.Join(tmpDir, "main.go")
+	content := `package main
+
+import (
+	"fmt"
+	"net/http"
+)
+
+func fetchUsers() {
+	resp, err := http.Get("https://api.example.com/users")
+	if err != nil {
+		panic(err)
+	}
+	defer resp.Body.Close()
+	fmt.Println(resp.StatusCode)
+}
+
+func createUser() {
+	resp, err := http.Post("https://api.example.com/users", "application/json", nil)
+	if err != nil {
+		panic(err)
+	}
+	defer resp.Body.Close()
+}
+
+func login() {
+	http.PostForm("https://api.example.com/login", nil)
+}
+
+func healthCheck() {
+	http.Head("https://api.example.com/health")
+}
+
+func dynamicURL(url string) {
+	http.Get(url)
+}
+
+func main() {
+	fetchUsers()
+	createUser()
+	login()
+	healthCheck()
+}
+`
+	if err := os.WriteFile(mainGo, []byte(content), 0644); err != nil {
+		t.Fatalf("failed to write dummy source: %v", err)
+	}
+	goMod := filepath.Join(tmpDir, "go.mod")
+	if err := os.WriteFile(goMod, []byte("module example.com/httpclient\n\ngo 1.22\n"), 0644); err != nil {
+		t.Fatalf("failed to write go.mod: %v", err)
+	}
+
+	// Build the test binary if needed.
+	repoRoot, _ := filepath.Abs("../../")
+	binPath := filepath.Join(repoRoot, "bin", "gograph-test")
+	if err := os.MkdirAll(filepath.Dir(binPath), 0755); err != nil {
+		t.Fatalf("failed to create bin directory: %v", err)
+	}
+	if _, err := os.Stat(binPath); os.IsNotExist(err) {
+		cmd := exec.Command("go", "build", "-o", binPath, filepath.Join(repoRoot, "cmd", "gograph", "main.go"))
+		cmd.Dir = repoRoot
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("failed to build test binary: %v\nOutput: %s", err, string(out))
+		}
+	}
+
+	runCmd := func(args ...string) (string, error) {
+		cmd := exec.Command(binPath, args...)
+		cmd.Dir = tmpDir
+		var out bytes.Buffer
+		cmd.Stdout = &out
+		cmd.Stderr = &out
+		err := cmd.Run()
+		return out.String(), err
+	}
+
+	// 1. Build the graph.
+	out, err := runCmd("build", tmpDir)
+	if err != nil {
+		t.Fatalf("build failed: %v\nOutput:\n%s", err, out)
+	}
+
+	// 2. Verify graph.json contains http_calls.
+	graphPath := filepath.Join(tmpDir, ".gograph", "graph.json")
+	data, err := os.ReadFile(graphPath)
+	if err != nil {
+		t.Fatalf("failed to read graph.json: %v", err)
+	}
+	var g struct {
+		HTTPCalls []map[string]any `json:"http_calls"`
+	}
+	if err := json.Unmarshal(data, &g); err != nil {
+		t.Fatalf("invalid graph.json: %v\nContent: %s", err, string(data))
+	}
+	if len(g.HTTPCalls) == 0 {
+		t.Fatal("expected at least one http_call in graph.json, got none")
+	}
+	t.Logf("graph.json contains %d HTTP call(s)", len(g.HTTPCalls))
+
+	// 3. Run gograph httpcalls (text mode).
+	out, err = runCmd("httpcalls")
+	if err != nil {
+		t.Fatalf("httpcalls failed: %v\nOutput:\n%s", err, out)
+	}
+	expected := []string{
+		"GET https://api.example.com/users",
+		"POST https://api.example.com/users",
+		"POST https://api.example.com/login",
+		"HEAD https://api.example.com/health",
+	}
+	for _, exp := range expected {
+		if !strings.Contains(out, exp) {
+			t.Errorf("expected httpcalls output to contain %q\nGot:\n%s", exp, out)
+		}
+	}
+	t.Logf("httpcalls text output:\n%s", out)
+
+	// 4. Test filtering.
+	out, err = runCmd("httpcalls", "POST")
+	if err != nil {
+		t.Fatalf("httpcalls POST failed: %v\nOutput:\n%s", err, out)
+	}
+	if !strings.Contains(out, "POST https://api.example.com/users") {
+		t.Errorf("expected filtered output to contain POST, got:\n%s", out)
+	}
+	if strings.Contains(out, "GET https://api.example.com/users") {
+		t.Errorf("filtered output should not contain GET, got:\n%s", out)
+	}
+	t.Logf("httpcalls POST filtered output:\n%s", out)
+
+	// 5. Test JSON output.
+	out, err = runCmd("httpcalls", "--json")
+	if err != nil {
+		t.Fatalf("httpcalls --json failed: %v\nOutput:\n%s", err, out)
+	}
+	var env map[string]interface{}
+	if err := json.Unmarshal([]byte(out), &env); err != nil {
+		t.Fatalf("Failed to parse JSON: %v\nOutput: %s", err, out)
+	}
+	if env["status"] != "ok" {
+		t.Errorf("expected JSON status 'ok', got %v", env["status"])
+	}
+	if env["command"] != "httpcalls" {
+		t.Errorf("expected JSON command 'httpcalls', got %v", env["command"])
+	}
+	results, ok := env["results"].([]interface{})
+	if !ok {
+		t.Fatalf("expected results array, got %T", env["results"])
+	}
+	if len(results) == 0 {
+		t.Fatal("expected non-empty results array")
+	}
+	t.Logf("httpcalls --json returned %d results", len(results))
+
+	// 6. Test empty results message.
+	out, err = runCmd("httpcalls", "NonExistentTermXYZ")
+	if err != nil {
+		t.Fatalf("httpcalls with no-match failed: %v\nOutput:\n%s", err, out)
+	}
+	if !strings.Contains(out, "No HTTP client calls found") {
+		t.Errorf("expected empty results message, got:\n%s", out)
+	}
+}

--- a/internal/graph/graph.go
+++ b/internal/graph/graph.go
@@ -30,7 +30,7 @@ type Graph struct {
 	Implements   []ImplementsEdge  `json:"implements,omitempty"`
 	Mutations    []MutationEdge    `json:"mutations,omitempty"`
 	Literals     []LiteralEdge     `json:"literals,omitempty"`
-	HttpCalls    []HttpCallEdge    `json:"http_calls,omitempty"`
+	HTTPCalls    []HTTPCallEdge    `json:"http_calls,omitempty"`
 	Baseline     *GraphBaseline    `json:"baseline,omitempty"`
 }
 
@@ -77,8 +77,8 @@ type LiteralEdge struct {
 	Line     int    `json:"line"`
 }
 
-// HttpCallEdge represents a detected HTTP client call (net/http).
-type HttpCallEdge struct {
+// HTTPCallEdge represents a detected HTTP client call (net/http).
+type HTTPCallEdge struct {
 	SourceFile     string   `json:"sourceFile"`
 	SourceLine     int      `json:"sourceLine"`
 	FunctionName   string   `json:"functionName"`

--- a/internal/graph/graph.go
+++ b/internal/graph/graph.go
@@ -30,6 +30,7 @@ type Graph struct {
 	Implements   []ImplementsEdge  `json:"implements,omitempty"`
 	Mutations    []MutationEdge    `json:"mutations,omitempty"`
 	Literals     []LiteralEdge     `json:"literals,omitempty"`
+	HttpCalls    []HttpCallEdge    `json:"http_calls,omitempty"`
 	Baseline     *GraphBaseline    `json:"baseline,omitempty"`
 }
 
@@ -74,6 +75,17 @@ type LiteralEdge struct {
 	Function string `json:"function"`
 	File     string `json:"file"`
 	Line     int    `json:"line"`
+}
+
+// HttpCallEdge represents a detected HTTP client call (net/http).
+type HttpCallEdge struct {
+	SourceFile     string   `json:"sourceFile"`
+	SourceLine     int      `json:"sourceLine"`
+	FunctionName   string   `json:"functionName"`
+	Method         string   `json:"method"`
+	URL            string   `json:"url"`
+	StaticSegments []string `json:"staticSegments"`
+	HasDynamic     bool     `json:"hasDynamic"`
 }
 
 // ImplementsEdge records absolute proof that a concrete type implements an interface.

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -154,6 +154,7 @@ func NewServer(g *graph.Graph, rebuild func() (*graph.Graph, error), buildGraph 
 				{"name": "gograph_envs", "purpose": "All os.Getenv/os.LookupEnv reads in the codebase. Filter by key name substring."},
 				{"name": "gograph_tests", "purpose": "Test functions that exercise a named symbol. Omit symbol to list all test edges."},
 				{"name": "gograph_hotspot", "purpose": "Functions ranked by fan-in (incoming call count). High fan-in = highest-risk change target."},
+				{"name": "gograph_httpcalls", "purpose": "All outbound HTTP client calls via net/http (Get, Post, PostForm, Head). Filter by method or URL."},
 				{"name": "gograph_changes", "purpose": "Symbols modified/added/deleted. Without git_ref: uncommitted changes. With git_ref: static diff vs that ref."},
 				{"name": "gograph_path", "purpose": "Shortest BFS call chain between two symbols. Confirms whether a handler reaches a given function."},
 				{"name": "gograph_complexity", "purpose": "Cyclomatic complexity per function, sorted highest first. Labels: LOW/MEDIUM/HIGH/VERY HIGH."},
@@ -1586,6 +1587,25 @@ func initNewTools(g *graph.Graph, rebuild func() (*graph.Graph, error), buildGra
 			}
 		}
 		results := search.Concurrency(g, term)
+		return formatResults(results), nil
+	})
+
+	// Tool: gograph_httpcalls
+	httpcallsTool := mcp.NewTool("gograph_httpcalls",
+		mcp.WithDescription("Find all outbound HTTP client calls detected in the codebase via net/http package-level functions: http.Get, http.Post, http.PostForm, http.Head. Requires .gograph/graph.json — run `gograph build .` first. Read-only; no side effects. Optional `term` filters by method, URL, or function name substring. WHEN TO USE: When auditing external API dependencies, understanding which services your code calls, or identifying all outbound HTTP traffic. NOT TO USE: For HTTP server route definitions (use gograph_routes). RETURNS: List of HTTP method, URL, static path segments, dynamic flag, calling function, and file/line; empty when no HTTP client calls match."),
+		mcp.WithString("term", mcp.Description("Optional filter term (matches method, URL, or function name — e.g., 'POST' or 'api.example.com')")),
+	)
+	addTool(httpcallsTool, func(_ context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		if newG, err := rebuild(); err == nil {
+			g = newG
+		}
+		term := ""
+		if args, ok := request.Params.Arguments.(map[string]any); ok {
+			if t, ok := args["term"].(string); ok {
+				term = t
+			}
+		}
+		results := search.HTTPCalls(g, term)
 		return formatResults(results), nil
 	})
 

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -30,7 +30,7 @@ type FileResult struct {
 	TestEdges   []graph.TestEdge
 	Mutations   []graph.MutationEdge
 	Literals    []graph.LiteralEdge
-	HttpCalls   []graph.HttpCallEdge
+	HTTPCalls   []graph.HTTPCallEdge
 }
 
 // ParseFile parses a single .go file and extracts its nodes.
@@ -554,16 +554,16 @@ func extractFuncDecl(fset *token.FileSet, d *ast.FuncDecl, relPath, pkgName, pkg
 			if method, ok := extractHTTPMethod(callee, call); ok && len(call.Args) >= 1 {
 				urlExpr := call.Args[0]
 				var urlStr string
-				hasDynamic := true
+				hasDynamic := false
 
 				if lit, ok2 := urlExpr.(*ast.BasicLit); ok2 && lit.Kind == token.STRING {
 					urlStr = strings.Trim(lit.Value, "\"")
-					hasDynamic = false
 				} else {
 					urlStr = exprName(urlExpr)
 					if urlStr == "" {
 						urlStr = "<dynamic>"
 					}
+					hasDynamic = true
 				}
 
 				var staticSegments []string
@@ -571,7 +571,7 @@ func extractFuncDecl(fset *token.FileSet, d *ast.FuncDecl, relPath, pkgName, pkg
 					staticSegments = extractStaticSegments(urlStr)
 				}
 
-				result.HttpCalls = append(result.HttpCalls, graph.HttpCallEdge{
+				result.HTTPCalls = append(result.HTTPCalls, graph.HTTPCallEdge{
 					SourceFile:     relPath,
 					SourceLine:     callPos.Line,
 					FunctionName:   callerName,
@@ -1148,8 +1148,14 @@ func envRead(call *ast.CallExpr, callee string, line int, file, fn string) (grap
 	}, true
 }
 
-// extractHTTPMethod checks whether a call expression is an HTTP client call
-// and returns the HTTP method (GET, POST, etc.) if so.
+// extractHTTPMethod checks whether a call expression is a package-level
+// net/http client call and returns the HTTP method (GET, POST, etc.) if so.
+//
+// Only unambiguous package-level calls are detected (http.Get, http.Post, etc.).
+// *http.Client method calls (client.Get, client.Do) are not detected here
+// because they cannot be reliably distinguished from other types' methods
+// without go/types type information. Support for those may be added in a
+// future --precise mode enhancement.
 func extractHTTPMethod(callee string, call *ast.CallExpr) (string, bool) {
 	switch callee {
 	case "http.Get":
@@ -1160,23 +1166,6 @@ func extractHTTPMethod(callee string, call *ast.CallExpr) (string, bool) {
 		return "POST", true
 	case "http.Head":
 		return "HEAD", true
-	}
-	// Check for *http.Client method calls by method name suffix.
-	sel, ok := call.Fun.(*ast.SelectorExpr)
-	if !ok {
-		return "", false
-	}
-	switch sel.Sel.Name {
-	case "Get":
-		return "GET", true
-	case "Post":
-		return "POST", true
-	case "PostForm":
-		return "POST", true
-	case "Head":
-		return "HEAD", true
-	case "Do":
-		return "GET", true
 	}
 	return "", false
 }

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -10,6 +10,7 @@ import (
 	"go/parser"
 	"go/printer"
 	"go/token"
+	"net/url"
 	"strings"
 
 	"github.com/ozgurcd/gograph/internal/graph"
@@ -29,6 +30,7 @@ type FileResult struct {
 	TestEdges   []graph.TestEdge
 	Mutations   []graph.MutationEdge
 	Literals    []graph.LiteralEdge
+	HttpCalls   []graph.HttpCallEdge
 }
 
 // ParseFile parses a single .go file and extracts its nodes.
@@ -546,6 +548,38 @@ func extractFuncDecl(fset *token.FileSet, d *ast.FuncDecl, relPath, pkgName, pkg
 						break
 					}
 				}
+			}
+
+			// HTTP Client Call Extraction
+			if method, ok := extractHTTPMethod(callee, call); ok && len(call.Args) >= 1 {
+				urlExpr := call.Args[0]
+				var urlStr string
+				hasDynamic := true
+
+				if lit, ok2 := urlExpr.(*ast.BasicLit); ok2 && lit.Kind == token.STRING {
+					urlStr = strings.Trim(lit.Value, "\"")
+					hasDynamic = false
+				} else {
+					urlStr = exprName(urlExpr)
+					if urlStr == "" {
+						urlStr = "<dynamic>"
+					}
+				}
+
+				var staticSegments []string
+				if !hasDynamic {
+					staticSegments = extractStaticSegments(urlStr)
+				}
+
+				result.HttpCalls = append(result.HttpCalls, graph.HttpCallEdge{
+					SourceFile:     relPath,
+					SourceLine:     callPos.Line,
+					FunctionName:   callerName,
+					Method:         method,
+					URL:            urlStr,
+					StaticSegments: staticSegments,
+					HasDynamic:     hasDynamic,
+				})
 			}
 
 			// Test edge: record which production symbols a test calls.
@@ -1112,6 +1146,52 @@ func envRead(call *ast.CallExpr, callee string, line int, file, fn string) (grap
 		Line:     line,
 		Function: fn,
 	}, true
+}
+
+// extractHTTPMethod checks whether a call expression is an HTTP client call
+// and returns the HTTP method (GET, POST, etc.) if so.
+func extractHTTPMethod(callee string, call *ast.CallExpr) (string, bool) {
+	switch callee {
+	case "http.Get":
+		return "GET", true
+	case "http.Post":
+		return "POST", true
+	case "http.PostForm":
+		return "POST", true
+	case "http.Head":
+		return "HEAD", true
+	}
+	// Check for *http.Client method calls by method name suffix.
+	sel, ok := call.Fun.(*ast.SelectorExpr)
+	if !ok {
+		return "", false
+	}
+	switch sel.Sel.Name {
+	case "Get":
+		return "GET", true
+	case "Post":
+		return "POST", true
+	case "PostForm":
+		return "POST", true
+	case "Head":
+		return "HEAD", true
+	case "Do":
+		return "GET", true
+	}
+	return "", false
+}
+
+// extractStaticSegments parses a URL string and returns non-empty path segments.
+func extractStaticSegments(rawURL string) []string {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return nil
+	}
+	path := strings.Trim(u.Path, "/")
+	if path == "" {
+		return nil
+	}
+	return strings.Split(path, "/")
 }
 
 func resolveStringLiteral(body *ast.BlockStmt, identName string) (string, bool) {

--- a/internal/parser/parser_httpclient_test.go
+++ b/internal/parser/parser_httpclient_test.go
@@ -1,0 +1,140 @@
+package parser_test
+
+import (
+	"go/token"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/ozgurcd/gograph/internal/parser"
+)
+
+func httpClientDir() string {
+	_, file, _, _ := runtime.Caller(0)
+	return filepath.Join(filepath.Dir(file), "testdata", "httpclient")
+}
+
+func TestParseFile_HTTPClientCalls(t *testing.T) {
+	fset := token.NewFileSet()
+	fixturePath := filepath.Join(httpClientDir(), "httpclient.go")
+	result, err := parser.ParseFile(fset, fixturePath, "httpclient/httpclient.go", "example.com/httpclient")
+	if err != nil {
+		t.Fatalf("ParseFile returned error: %v", err)
+	}
+
+	t.Run("http.Get with static URL", func(t *testing.T) {
+		found := false
+		for _, h := range result.HttpCalls {
+			if h.Method == "GET" && h.URL == "https://api.example.com/users" && !h.HasDynamic {
+				found = true
+				if len(h.StaticSegments) != 1 || h.StaticSegments[0] != "users" {
+					t.Errorf("unexpected static segments: %v", h.StaticSegments)
+				}
+			}
+		}
+		if !found {
+			t.Error("expected http.Get call to https://api.example.com/users")
+		}
+	})
+
+	t.Run("http.Post with static URL", func(t *testing.T) {
+		found := false
+		for _, h := range result.HttpCalls {
+			if h.Method == "POST" && h.URL == "https://api.example.com/users" && !h.HasDynamic {
+				found = true
+			}
+		}
+		if !found {
+			t.Error("expected http.Post call")
+		}
+	})
+
+	t.Run("http.PostForm with static URL", func(t *testing.T) {
+		found := false
+		for _, h := range result.HttpCalls {
+			if h.Method == "POST" && h.URL == "https://api.example.com/login" && !h.HasDynamic {
+				found = true
+			}
+		}
+		if !found {
+			t.Error("expected http.PostForm call")
+		}
+	})
+
+	t.Run("http.Head with static URL", func(t *testing.T) {
+		found := false
+		for _, h := range result.HttpCalls {
+			if h.Method == "HEAD" && h.URL == "https://api.example.com/health" && !h.HasDynamic {
+				found = true
+			}
+		}
+		if !found {
+			t.Error("expected http.Head call")
+		}
+	})
+
+	t.Run("client.Get with dynamic URL", func(t *testing.T) {
+		found := false
+		for _, h := range result.HttpCalls {
+			if h.Method == "GET" && h.URL == "url" && h.HasDynamic && h.FunctionName == "dynamicURL" {
+				found = true
+			}
+		}
+		if !found {
+			t.Error("expected client.Get call in dynamicURL")
+		}
+	})
+
+	t.Run("client.Get with concatenated URL", func(t *testing.T) {
+		found := false
+		for _, h := range result.HttpCalls {
+			if h.Method == "GET" && h.FunctionName == "getUser" {
+				found = true
+			}
+		}
+		if !found {
+			t.Error("expected client.Get call in getUser")
+		}
+	})
+
+	t.Run("multi-segment static URL", func(t *testing.T) {
+		found := false
+		for _, h := range result.HttpCalls {
+			if h.Method == "GET" && h.URL == "https://user-svc/api/v2/users" && !h.HasDynamic {
+				found = true
+				if len(h.StaticSegments) != 3 || h.StaticSegments[0] != "api" || h.StaticSegments[1] != "v2" || h.StaticSegments[2] != "users" {
+					t.Errorf("unexpected static segments for multi-segment URL: %v", h.StaticSegments)
+				}
+			}
+		}
+		if !found {
+			t.Error("expected http.Get call to https://user-svc/api/v2/users")
+		}
+	})
+
+	t.Run("client.Do detected", func(t *testing.T) {
+		found := false
+		for _, h := range result.HttpCalls {
+			if h.FunctionName == "doRequest" && h.Method == "GET" {
+				found = true
+			}
+		}
+		if !found {
+			t.Error("expected client.Do call in doRequest")
+		}
+	})
+
+	t.Run("function name populated", func(t *testing.T) {
+		for _, h := range result.HttpCalls {
+			if h.FunctionName == "" {
+				t.Error("expected non-empty FunctionName")
+			}
+			if h.SourceLine == 0 {
+				t.Error("expected non-zero SourceLine")
+			}
+			if h.SourceFile == "" {
+				t.Error("expected non-empty SourceFile")
+			}
+		}
+	})
+}

--- a/internal/parser/parser_httpclient_test.go
+++ b/internal/parser/parser_httpclient_test.go
@@ -24,7 +24,7 @@ func TestParseFile_HTTPClientCalls(t *testing.T) {
 
 	t.Run("http.Get with static URL", func(t *testing.T) {
 		found := false
-		for _, h := range result.HttpCalls {
+		for _, h := range result.HTTPCalls {
 			if h.Method == "GET" && h.URL == "https://api.example.com/users" && !h.HasDynamic {
 				found = true
 				if len(h.StaticSegments) != 1 || h.StaticSegments[0] != "users" {
@@ -39,7 +39,7 @@ func TestParseFile_HTTPClientCalls(t *testing.T) {
 
 	t.Run("http.Post with static URL", func(t *testing.T) {
 		found := false
-		for _, h := range result.HttpCalls {
+		for _, h := range result.HTTPCalls {
 			if h.Method == "POST" && h.URL == "https://api.example.com/users" && !h.HasDynamic {
 				found = true
 			}
@@ -51,7 +51,7 @@ func TestParseFile_HTTPClientCalls(t *testing.T) {
 
 	t.Run("http.PostForm with static URL", func(t *testing.T) {
 		found := false
-		for _, h := range result.HttpCalls {
+		for _, h := range result.HTTPCalls {
 			if h.Method == "POST" && h.URL == "https://api.example.com/login" && !h.HasDynamic {
 				found = true
 			}
@@ -63,7 +63,7 @@ func TestParseFile_HTTPClientCalls(t *testing.T) {
 
 	t.Run("http.Head with static URL", func(t *testing.T) {
 		found := false
-		for _, h := range result.HttpCalls {
+		for _, h := range result.HTTPCalls {
 			if h.Method == "HEAD" && h.URL == "https://api.example.com/health" && !h.HasDynamic {
 				found = true
 			}
@@ -73,33 +73,9 @@ func TestParseFile_HTTPClientCalls(t *testing.T) {
 		}
 	})
 
-	t.Run("client.Get with dynamic URL", func(t *testing.T) {
-		found := false
-		for _, h := range result.HttpCalls {
-			if h.Method == "GET" && h.URL == "url" && h.HasDynamic && h.FunctionName == "dynamicURL" {
-				found = true
-			}
-		}
-		if !found {
-			t.Error("expected client.Get call in dynamicURL")
-		}
-	})
-
-	t.Run("client.Get with concatenated URL", func(t *testing.T) {
-		found := false
-		for _, h := range result.HttpCalls {
-			if h.Method == "GET" && h.FunctionName == "getUser" {
-				found = true
-			}
-		}
-		if !found {
-			t.Error("expected client.Get call in getUser")
-		}
-	})
-
 	t.Run("multi-segment static URL", func(t *testing.T) {
 		found := false
-		for _, h := range result.HttpCalls {
+		for _, h := range result.HTTPCalls {
 			if h.Method == "GET" && h.URL == "https://user-svc/api/v2/users" && !h.HasDynamic {
 				found = true
 				if len(h.StaticSegments) != 3 || h.StaticSegments[0] != "api" || h.StaticSegments[1] != "v2" || h.StaticSegments[2] != "users" {
@@ -112,20 +88,8 @@ func TestParseFile_HTTPClientCalls(t *testing.T) {
 		}
 	})
 
-	t.Run("client.Do detected", func(t *testing.T) {
-		found := false
-		for _, h := range result.HttpCalls {
-			if h.FunctionName == "doRequest" && h.Method == "GET" {
-				found = true
-			}
-		}
-		if !found {
-			t.Error("expected client.Do call in doRequest")
-		}
-	})
-
 	t.Run("function name populated", func(t *testing.T) {
-		for _, h := range result.HttpCalls {
+		for _, h := range result.HTTPCalls {
 			if h.FunctionName == "" {
 				t.Error("expected non-empty FunctionName")
 			}

--- a/internal/parser/parser_staticsegments_test.go
+++ b/internal/parser/parser_staticsegments_test.go
@@ -1,0 +1,82 @@
+package parser
+
+import (
+	"testing"
+)
+
+func TestExtractStaticSegments(t *testing.T) {
+	tests := []struct {
+		name     string
+		rawURL   string
+		expected []string
+	}{
+		{
+			name:     "simple path",
+			rawURL:   "https://api.example.com/users",
+			expected: []string{"users"},
+		},
+		{
+			name:     "multi-segment path",
+			rawURL:   "https://user-svc/api/v2/users",
+			expected: []string{"api", "v2", "users"},
+		},
+		{
+			name:     "with query string (ignored)",
+			rawURL:   "https://api.example.com/users?page=1&limit=10",
+			expected: []string{"users"},
+		},
+		{
+			name:     "with fragment (ignored)",
+			rawURL:   "https://api.example.com/users#section",
+			expected: []string{"users"},
+		},
+		{
+			name:     "trailing slash",
+			rawURL:   "https://api.example.com/",
+			expected: nil,
+		},
+		{
+			name:     "root path only",
+			rawURL:   "https://api.example.com",
+			expected: nil,
+		},
+		{
+			name:     "empty URL",
+			rawURL:   "",
+			expected: nil,
+		},
+		{
+			name:     "deeply nested path",
+			rawURL:   "https://svc.example.com/a/b/c/d/e",
+			expected: []string{"a", "b", "c", "d", "e"},
+		},
+		{
+			name:     "path with trailing slash",
+			rawURL:   "https://svc.example.com/api/v2/",
+			expected: []string{"api", "v2"},
+		},
+		{
+			name:     "malformed URL",
+			rawURL:   "://invalid",
+			expected: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := extractStaticSegments(tt.rawURL)
+			if len(got) == 0 && len(tt.expected) == 0 {
+				return
+			}
+			if len(got) != len(tt.expected) {
+				t.Errorf("extractStaticSegments(%q) = %v, want %v", tt.rawURL, got, tt.expected)
+				return
+			}
+			for i := range got {
+				if got[i] != tt.expected[i] {
+					t.Errorf("extractStaticSegments(%q)[%d] = %q, want %q", tt.rawURL, i, got[i], tt.expected[i])
+				}
+			}
+		})
+	}
+}

--- a/internal/parser/testdata/httpclient/httpclient.go
+++ b/internal/parser/testdata/httpclient/httpclient.go
@@ -4,8 +4,6 @@ import (
 	"net/http"
 )
 
-var globalClient = &http.Client{}
-
 func fetchUsers() {
 	resp, err := http.Get("https://api.example.com/users")
 	if err != nil {
@@ -14,12 +12,11 @@ func fetchUsers() {
 	defer resp.Body.Close()
 }
 
-func getUser(id string) {
-	globalClient.Get("https://api.example.com/users/" + id)
-}
-
 func createUser() {
-	resp, _ := http.Post("https://api.example.com/users", "application/json", nil)
+	resp, err := http.Post("https://api.example.com/users", "application/json", nil)
+	if err != nil {
+		panic(err)
+	}
 	defer resp.Body.Close()
 }
 
@@ -31,14 +28,6 @@ func healthCheck() {
 	http.Head("https://api.example.com/health")
 }
 
-func dynamicURL(url string) {
-	globalClient.Get(url)
-}
-
 func multiSegment() {
 	http.Get("https://user-svc/api/v2/users")
-}
-
-func doRequest(req *http.Request) {
-	globalClient.Do(req)
 }

--- a/internal/parser/testdata/httpclient/httpclient.go
+++ b/internal/parser/testdata/httpclient/httpclient.go
@@ -1,0 +1,44 @@
+package httpclient
+
+import (
+	"net/http"
+)
+
+var globalClient = &http.Client{}
+
+func fetchUsers() {
+	resp, err := http.Get("https://api.example.com/users")
+	if err != nil {
+		panic(err)
+	}
+	defer resp.Body.Close()
+}
+
+func getUser(id string) {
+	globalClient.Get("https://api.example.com/users/" + id)
+}
+
+func createUser() {
+	resp, _ := http.Post("https://api.example.com/users", "application/json", nil)
+	defer resp.Body.Close()
+}
+
+func login() {
+	http.PostForm("https://api.example.com/login", nil)
+}
+
+func healthCheck() {
+	http.Head("https://api.example.com/health")
+}
+
+func dynamicURL(url string) {
+	globalClient.Get(url)
+}
+
+func multiSegment() {
+	http.Get("https://user-svc/api/v2/users")
+}
+
+func doRequest(req *http.Request) {
+	globalClient.Do(req)
+}

--- a/internal/search/search.go
+++ b/internal/search/search.go
@@ -1312,6 +1312,35 @@ func Envs(g *graph.Graph, term string) []Result {
 	return results
 }
 
+// HTTPCalls returns all detected HTTP client calls in the graph,
+// optionally filtered by a keyword term (matches method, URL, or function name).
+func HTTPCalls(g *graph.Graph, term string) []Result {
+	nl := strings.ToLower(term)
+	var results []Result
+	for _, h := range g.HTTPCalls {
+		if term == "" ||
+			strings.Contains(strings.ToLower(h.Method), nl) ||
+			strings.Contains(strings.ToLower(h.URL), nl) ||
+			strings.Contains(strings.ToLower(h.FunctionName), nl) {
+			detail := fmt.Sprintf("%s %s", h.Method, h.URL)
+			if h.HasDynamic {
+				detail += " [dynamic]"
+			}
+			detail += " in " + h.FunctionName
+			results = append(results, Result{
+				Kind:   "httpcall",
+				Name:   fmt.Sprintf("%s %s", h.Method, h.URL),
+				File:   h.SourceFile,
+				Line:   h.SourceLine,
+				Detail: detail,
+				Score:  10,
+			})
+		}
+	}
+	sortResults(results)
+	return results
+}
+
 // Interfaces returns all interfaces that the named struct satisfies,
 // using duck-typing: a struct satisfies an interface if it has all methods
 // listed in InterfaceMethods (by name). Only interfaces defined in the graph


### PR DESCRIPTION
Apologies for closing the original PR #21 — I deleted the branch while preparing fixes instead of force-pushing.

Adds HTTPCallEdge, a new edge type detecting outbound HTTP client calls via net/http: http.Get, http.Post, http.PostForm, http.Head, including static/dynamic URL distinction with path segment extraction.

Also adds:
- `gograph httpcalls [term]` CLI command to query the data
- `gograph_httpcalls` MCP tool (filter by method, URL, or function)
- E2E test validating the full build-to-query pipeline

Only package-level calls are detected. *http.Client method calls (client.Get, client.Do) are deferred to a future --precise enhancement.

Commits 1+2 (extraction + review fixes) are self-contained if you'd prefer to merge those first and review the query layer separately. Let me know.
