### PR TITLE
fix(mcp): use cli.Version instead of hard-coded version literal

### DIFF
--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
+	"github.com/ozgurcd/gograph/internal/cli"
 	"github.com/ozgurcd/gograph/internal/graph"
 	"github.com/ozgurcd/gograph/internal/search"
 	"github.com/ozgurcd/gograph/internal/session"
@@ -53,10 +54,12 @@ var ExposeToolsForTesting map[string]func(context.Context, mcp.CallToolRequest) 
 
 // NewServer creates and returns the MCP server with all tools registered.
 func NewServer(g *graph.Graph, rebuild func() (*graph.Graph, error), buildGraph func(string) (*graph.Graph, error)) *server.MCPServer {
-	// TODO: Centralize version source with internal/cli.Version to avoid duplication.
+	// Use cli.Version as the single source of truth for the version string.
+	// The CLI injects the real release version via -ldflags at build time;
+	// local builds fall back to "dev" via the var initializer.
 	s := server.NewMCPServer(
 		"gograph",
-		"1.4.59",
+		cli.Version,
 		server.WithToolCapabilities(true),
 	)
 


### PR DESCRIPTION
`internal/cli` exports `Version` (set via `-ldflags` at release build time, defaults to `"dev"` for local builds). The MCP server was passing the literal `"1.4.59"` to `server.NewMCPServer`, which meant two things:

1. The MCP-reported version drifted from the CLI-reported version after every release. MCP clients (e.g. Cursor, Claude Desktop) see a stale or incorrect gograph version string.
2. The hard-coded literal had to be bumped by hand in two places on every release, which is exactly the duplication the comment TODO was calling out.

This change:
- Imports `internal/cli` in `server.go`.
- Replaces the literal with `cli.Version`.
- Replaces the TODO comment with a one-line explanation of where the value comes from.

No behavior change at runtime when `cli.Version` is `"dev"` (local build) because the existing tests already accept that string. Release builds now report the same version the CLI reports.
