### PR TITLE
fix(cli): recognize hook-guard alternations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,17 @@ jobs:
       run: govulncheck ./...
 
     - name: Build and structurally validate all MCP bundles
-      run: make mcpb-build mcpb-verify
+      shell: bash
+      run: |
+        set -euo pipefail
+        make mcpb-build
+        version="$(awk -F ' = ' '$1 == "current_version" { print $2 }' .bumpversion.cfg)"
+        test -n "$version"
+        go run ./cmd/mcpb-release render-server \
+          --version "$version" \
+          --input .release-mcpb \
+          --output "$RUNNER_TEMP/server.json"
+        make mcpb-verify MCPB_SERVER="$RUNNER_TEMP/server.json"
 
     - name: Smoke-test the native MCP bundle
       run: make mcpb-smoke

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -107,6 +107,15 @@
 
 ### Fixes
 
+#### Hook Guard Alternation Parsing
+`gograph hook-guard` now recognizes identifier-only alternations without
+mistaking quoted regex pipes for shell pipelines. Basic `grep` `\|`, extended
+`grep`/ripgrep `|`, repeated pattern flags, ordered glob/type selectors,
+redirections, context values, and fixed-string/engine modes are parsed according
+to their command semantics. Literal or mixed-regex searches still fail open;
+mixed targets or exempt branches no longer hide a Go-symbol search. Focused unit
+and process-level tests cover the reported escaped-pipe false negative.
+
 #### Empty Build Targets Do Not Write Artifacts
 `gograph build` now exits with `no Go files in <path>` before running precise analysis or writing artifacts when the scanner finds zero Go files after ignore filtering.
 

--- a/docs-site/content/docs/agent-integration.md
+++ b/docs-site/content/docs/agent-integration.md
@@ -231,6 +231,14 @@ If the agent tries to run `grep -rn "MyStruct" .`, the hook guard blocks the com
 
 The hook is a steering aid, not a security boundary: it targets likely Go-identifier searches and intentionally allows comment, documentation, and non-Go searches.
 
+Identifier-only alternations are also steered: basic `grep` recognizes `\|`,
+while `grep -E` and `rg` recognize bare `|`. Literal-pipe patterns in
+fixed-string mode, escaped pipes in `grep -E`/`rg`, mixed regex/literal patterns,
+and unsupported dynamic shell syntax remain allowed. Quotes, pattern flags,
+glob/context option values, and the first shell pipeline stage are parsed before
+classification. Mixed targets are blocked when any selected path can contain Go
+source; comment markers do not hide another symbol branch.
+
 ---
 
 ## Workspace Steering Rules

--- a/docs-site/content/docs/command-reference.md
+++ b/docs-site/content/docs/command-reference.md
@@ -557,7 +557,7 @@ Registers Claude Desktop MCP configuration, injects shared `~/.claude/CLAUDE.md`
 ```bash
 gograph hook-guard
 ```
-Called by the Claude Code `PreToolUse` hook. Intercepts incoming tool-call JSON over `stdin`; blocks likely `grep`/`rg` Go-symbol searches with exit code 2 and allows non-Go/comment searches.
+Called by the Claude Code `PreToolUse` hook. Intercepts incoming tool-call JSON over `stdin`; blocks likely `grep`/`rg` Go-symbol searches with exit code 2 and allows non-Go/comment-only searches. Identifier-only alternations are recognized according to grep/ripgrep regex mode; literal-pipe patterns in fixed-string mode and escaped pipes in extended grep/ripgrep remain allowed.
 
 ### version and help
 ```bash

--- a/docs/claude-code-integration.md
+++ b/docs/claude-code-integration.md
@@ -121,15 +121,21 @@ The installer exits non-zero if any step fails. Restart Claude Desktop / Claude 
 
 The hook (`gograph hook-guard`) runs automatically before every `Bash` tool call Claude makes. When Claude tries to `grep` for a Go symbol, the hook:
 
-1. Detects it is a Go symbol search (pattern matches a valid Go identifier: `[A-Za-z_][a-zA-Z0-9_]{2,}`)
+1. Detects it is a Go symbol search (every non-exempt pattern branch is a valid identifier or an identifier-only alternation, with each branch matching `[A-Za-z_][a-zA-Z0-9_]{2,}`)
 2. Blocks the call (exit code `2`) and outputs which `gograph` tool to use instead
 3. Claude immediately retries using the correct `gograph_query` / `gograph_context` / etc. call
 
 **The hook is smart — it only intercepts symbol searches.** These pass through unchanged:
-- Searches in non-Go files (`*.yaml`, `*.md`, `*.sql`, `*.sh`)
-- Comment/doc searches (TODO, FIXME, HACK, DEPRECATED)
-- Searches in `docs/`, `.github/`, `testdata/`, `migrations/`
-- Short patterns or patterns with regex special characters
+- Searches targeting only non-Go files (`*.yaml`, `*.md`, `*.sql`, `*.sh`)
+- Comment/doc-only searches (TODO, FIXME, HACK, DEPRECATED)
+- Searches targeting only `docs/`, `.github/`, `testdata/`, or `migrations/`
+- Short patterns and patterns containing non-identifier regex/literal text
+- Literal-pipe patterns in fixed-string mode and escaped pipes in `grep -E`/`rg`
+
+Alternation is mode-aware: basic `grep` uses `\|`; `grep -E` and `rg` use bare
+`|`. The hook understands direct-command quoting, pattern flags, glob/context
+option values, and the first shell pipeline stage. Unsupported or dynamic shell
+syntax is allowed because the hook is steering rather than a security boundary.
 
 ### Claude Code (CLI) — Per-Project Registration
 

--- a/docs/coding-agent-usage.md
+++ b/docs/coding-agent-usage.md
@@ -136,21 +136,30 @@ The hook (`gograph hook-guard`) is invoked automatically by Claude Code before e
 
 1. Reads the tool call JSON from stdin.
 2. Checks if the command is `grep` or `rg`.
-3. If targeting `.go` files and the search pattern looks like a Go identifier (PascalCase/camelCase, 3+ chars) → **blocks** with exit code `2` and tells Claude which `gograph` tool to use instead.
+3. If the search can cover Go files and every non-exempt pattern branch is either one Go identifier or an identifier-only alternation (3+ ASCII identifier characters per branch) → **blocks** with exit code `2` and tells Claude which `gograph` tool to use instead.
 4. Otherwise → **allows** with exit code `0`.
 
 **Allowed through (not blocked):**
-- Searches explicitly targeting non-Go files (`*.yaml`, `*.md`, `*.sql`, etc.)
-- Comment/doc searches (TODO, FIXME, HACK, etc.)
-- Searches in `docs/`, `.github/`, `testdata/`, `migrations/`
-- Patterns that don't look like Go identifiers (short strings, regex with special chars)
+- Searches targeting only non-Go files (`*.yaml`, `*.md`, `*.sql`, etc.)
+- Comment/doc-only searches (TODO, FIXME, HACK, etc.)
+- Searches targeting only `docs/`, `.github/`, `testdata/`, or `migrations/`
+- Patterns containing non-identifier regex or literal text. In particular,
+  literal-pipe patterns in fixed-string mode and escaped pipes in `grep -E`/`rg`
+  remain text searches.
 
 **Blocked and redirected:**
 ```bash
 grep -r "ValidateToken" .        # → gograph_query "ValidateToken"
-rg "UserService" --include=*.go  # → gograph_context "UserService"
+rg "UserService" -g '*.go' .     # → gograph_context "UserService"
 grep -rn "runCheck" .            # → gograph_callers "runCheck"
+grep -rn 'LoadUser\|SaveUser' .   # basic grep alternation → LoadUser first
+rg 'LoadUser|SaveUser' -g '*.go'  # ripgrep alternation → LoadUser first
 ```
+
+Alternation follows the selected search dialect: basic `grep` uses `\|`, while
+`grep -E` and `rg` use bare `|`. The hook parses direct `grep`/`rg` arguments,
+option values, quotes, and the first shell pipeline stage; malformed or dynamic
+shell syntax fails open.
 
 The hook is steering, not a correctness boundary. If graph precision is
 `ast`/`precise_fallback`, a result is ambiguous, or a known call is missing,

--- a/internal/cli/e2e_test.go
+++ b/internal/cli/e2e_test.go
@@ -414,17 +414,17 @@ func TestE2E_ClaudePluginInstall(t *testing.T) {
 func TestE2E_HookGuard(t *testing.T) {
 	binPath := buildTestBinary(t)
 	cmd := exec.Command(binPath, "hook-guard")
-	cmd.Stdin = strings.NewReader(`{"tool_name":"Bash","tool_input":{"command":"rg UserService --include=*.go"}}`)
+	cmd.Stdin = strings.NewReader(`{"tool_name":"Bash","tool_input":{"command":"grep -rn 'runHookGuard\\|evaluateHookCommand' internal/cli/*.go"}}`)
 	out, err := cmd.CombinedOutput()
 	if exitErr, ok := err.(*exec.ExitError); !ok || exitErr.ExitCode() != 2 {
 		t.Fatalf("hook-guard exit = %v, want 2\n%s", err, out)
 	}
-	if !strings.Contains(string(out), "blocked grep") || !strings.Contains(string(out), `gograph_context "UserService"`) {
+	if !strings.Contains(string(out), "blocked grep") || !strings.Contains(string(out), `gograph_context "runHookGuard"`) {
 		t.Fatalf("hook-guard did not provide the documented redirect:\n%s", out)
 	}
 
 	allow := exec.Command(binPath, "hook-guard")
-	allow.Stdin = strings.NewReader(`{"tool_name":"Bash","tool_input":{"command":"rg TODO --include=*.go"}}`)
+	allow.Stdin = strings.NewReader(`{"tool_name":"Bash","tool_input":{"command":"rg TODO -g '*.go'"}}`)
 	if out, err := allow.CombinedOutput(); err != nil {
 		t.Fatalf("hook-guard should allow comment search: %v\n%s", err, out)
 	}

--- a/internal/cli/hook_guard.go
+++ b/internal/cli/hook_guard.go
@@ -3,9 +3,8 @@ package cli
 import (
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
-	"regexp"
-	"strings"
 )
 
 // hookGuardInput is the JSON structure Claude Code sends to PreToolUse hooks.
@@ -33,45 +32,17 @@ func runHookGuard() int {
 
 // evaluateHookCommand returns 2 (block) or 0 (allow).
 func evaluateHookCommand(command string) int {
-	// Only intercept grep / rg
-	if !regexp.MustCompile(`^\s*(grep|rg)\b`).MatchString(command) {
+	return evaluateHookCommandTo(command, os.Stdout)
+}
+
+func evaluateHookCommandTo(command string, output io.Writer) int {
+	decision := classifyHookCommand(command)
+	if !decision.block {
 		return 0
 	}
+	pattern := decision.symbols[0]
 
-	// Allow if targeting explicit non-Go extensions
-	nonGo := regexp.MustCompile(`\.(yaml|yml|json|md|sh|toml|env|sql|txt|html|css|js|ts|py|rb|java|c|cpp|h|rs)`)
-	if nonGo.MatchString(command) {
-		return 0
-	}
-
-	// Allow comment/doc searches
-	if regexp.MustCompile(`(?i)(TODO|FIXME|HACK|XXX|NOTE|BUG|DEPRECATED)`).MatchString(command) {
-		return 0
-	}
-
-	// Allow explicit non-code directory searches
-	if regexp.MustCompile(`(docs/|\.github/|testdata/|migrations/)`).MatchString(command) {
-		return 0
-	}
-
-	// Must target Go files or be a broad recursive search to proceed
-	goTarget := regexp.MustCompile(`(--include=.*\.go|\.go\b)`)
-	broadSearch := regexp.MustCompile(`(grep\s+-[a-zA-Z]*r|^rg\b|\brg\s)`)
-	if !goTarget.MatchString(command) && !broadSearch.MatchString(command) {
-		return 0
-	}
-
-	pattern := extractGrepPattern(command)
-	if pattern == "" {
-		return 0
-	}
-
-	// Only block if pattern looks like a Go identifier (3+ alphanum chars)
-	if !regexp.MustCompile(`^[A-Za-z_][a-zA-Z0-9_]{2,}$`).MatchString(pattern) {
-		return 0
-	}
-
-	fmt.Printf(`gograph-guard: blocked grep — this looks like a Go symbol search.
+	_, _ = fmt.Fprintf(output, `gograph-guard: blocked grep — this looks like a Go symbol search.
   Blocked:  %s
   Start with gograph's AST-derived structural tools:
     gograph_query "%s"          search symbols, files, packages
@@ -86,23 +57,4 @@ func evaluateHookCommand(command string) int {
     grep -r "..." --include="*.yaml"
 `, command, pattern, pattern, pattern, pattern)
 	return 2
-}
-
-// extractGrepPattern pulls the search pattern out of a grep/rg command string.
-func extractGrepPattern(command string) string {
-	s := regexp.MustCompile(`^\s*(grep|rg)\s+`).ReplaceAllString(command, "")
-	s = regexp.MustCompile(`--\S+\s*`).ReplaceAllString(s, "")
-	s = regexp.MustCompile(`-[a-zA-Z]+\s*`).ReplaceAllString(s, "")
-	if idx := strings.IndexAny(s, "|>"); idx != -1 {
-		s = s[:idx]
-	}
-	parts := strings.Fields(s)
-	if len(parts) == 0 {
-		return ""
-	}
-	pattern := strings.Trim(parts[0], `"'`)
-	if strings.HasPrefix(pattern, "/") || strings.HasPrefix(pattern, ".") {
-		return ""
-	}
-	return pattern
 }

--- a/internal/cli/hook_guard_parser.go
+++ b/internal/cli/hook_guard_parser.go
@@ -1,0 +1,1214 @@
+package cli
+
+import (
+	"regexp"
+	"strings"
+	"unicode"
+)
+
+type hookSearchTool uint8
+
+const (
+	hookToolGrep hookSearchTool = iota
+	hookToolRipgrep
+)
+
+type hookPatternMode uint8
+
+const (
+	hookPatternBRE hookPatternMode = iota
+	hookPatternERE
+	hookPatternFixed
+)
+
+type hookSearchInvocation struct {
+	tool            hookSearchTool
+	mode            hookPatternMode
+	patterns        []string
+	paths           []string
+	inputPaths      []string
+	selectors       []hookSelector
+	recursive       bool
+	globInsensitive bool
+	explicitPattern bool
+}
+
+type hookSelectorKind uint8
+
+const (
+	hookSelectorIncludeGlob hookSelectorKind = iota
+	hookSelectorExcludeGlob
+	hookSelectorIncludeType
+	hookSelectorExcludeType
+)
+
+type hookSelector struct {
+	kind            hookSelectorKind
+	value           string
+	caseInsensitive bool
+}
+
+type hookDecision struct {
+	block   bool
+	symbols []string
+}
+
+var hookIdentifierPattern = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]{2,}$`)
+var hookGoValuePattern = regexp.MustCompile(`\.go(?:$|[,}])`)
+
+var hookCommentMarkers = map[string]struct{}{
+	"bug":        {},
+	"deprecated": {},
+	"fixme":      {},
+	"hack":       {},
+	"note":       {},
+	"todo":       {},
+	"xxx":        {},
+}
+
+var hookGoKeywords = map[string]struct{}{
+	"break": {}, "case": {}, "chan": {}, "const": {}, "continue": {},
+	"default": {}, "defer": {}, "else": {}, "fallthrough": {}, "for": {},
+	"func": {}, "go": {}, "goto": {}, "if": {}, "import": {},
+	"interface": {}, "map": {}, "package": {}, "range": {}, "return": {},
+	"select": {}, "struct": {}, "switch": {}, "type": {}, "var": {},
+}
+
+func classifyHookCommand(command string) hookDecision {
+	argv, inputPaths, ok := lexHookCommand(command)
+	if !ok {
+		return hookDecision{}
+	}
+
+	invocation, ok := parseHookSearchInvocation(argv)
+	if !ok {
+		return hookDecision{}
+	}
+	invocation.inputPaths = inputPaths
+	if !hookSearchesGo(invocation) {
+		return hookDecision{}
+	}
+
+	seen := make(map[string]struct{})
+	var symbols []string
+	for _, pattern := range invocation.patterns {
+		patternSymbols, pure := pureHookSymbolAlternatives(pattern, invocation.mode)
+		if !pure {
+			return hookDecision{}
+		}
+		for _, symbol := range patternSymbols {
+			if hookSymbolExempt(symbol) {
+				continue
+			}
+			if _, exists := seen[symbol]; exists {
+				continue
+			}
+			seen[symbol] = struct{}{}
+			symbols = append(symbols, symbol)
+		}
+	}
+	if len(symbols) == 0 {
+		return hookDecision{}
+	}
+	return hookDecision{block: true, symbols: symbols}
+}
+
+// lexHookCommand cooks the arguments of the first simple shell command. It is
+// deliberately limited: unsupported expansion or malformed quoting fails open
+// because the hook is workflow steering, not a shell security boundary.
+func lexHookCommand(command string) ([]string, []string, bool) {
+	lexer := hookShellLexer{command: command}
+	for lexer.index < len(command) {
+		var step hookLexStep
+		switch {
+		case lexer.inSingle:
+			step = lexer.consumeSingleQuoted()
+		case lexer.inDouble:
+			step = lexer.consumeDoubleQuoted()
+		default:
+			step = lexer.consumeUnquoted()
+		}
+		if step == hookLexInvalid {
+			return nil, nil, false
+		}
+		if step == hookLexStop {
+			return lexer.argv, lexer.inputPaths, len(lexer.argv) > 0
+		}
+		lexer.index++
+	}
+	return lexer.finish()
+}
+
+type hookLexStep uint8
+
+const (
+	hookLexContinue hookLexStep = iota
+	hookLexStop
+	hookLexInvalid
+)
+
+type hookShellLexer struct {
+	command        string
+	index          int
+	argv           []string
+	inputPaths     []string
+	word           strings.Builder
+	inSingle       bool
+	inDouble       bool
+	started        bool
+	redirectTarget hookRedirectTarget
+	recordInput    bool
+}
+
+type hookRedirectTarget uint8
+
+const (
+	hookRedirectNone hookRedirectTarget = iota
+	hookRedirectOutput
+	hookRedirectInput
+)
+
+func (lexer *hookShellLexer) consumeSingleQuoted() hookLexStep {
+	char := lexer.command[lexer.index]
+	if char == '\'' {
+		lexer.inSingle = false
+		return hookLexContinue
+	}
+	lexer.append(char)
+	return hookLexContinue
+}
+
+func (lexer *hookShellLexer) consumeDoubleQuoted() hookLexStep {
+	char := lexer.command[lexer.index]
+	switch char {
+	case '"':
+		lexer.inDouble = false
+	case '$', '`':
+		return hookLexInvalid
+	case '\\':
+		return lexer.consumeDoubleQuotedEscape()
+	default:
+		lexer.append(char)
+	}
+	return hookLexContinue
+}
+
+func (lexer *hookShellLexer) consumeDoubleQuotedEscape() hookLexStep {
+	if lexer.index+1 >= len(lexer.command) {
+		return hookLexInvalid
+	}
+	next := lexer.command[lexer.index+1]
+	switch next {
+	case '$', '`', '"', '\\':
+		lexer.append(next)
+		lexer.index++
+	case '\n':
+		lexer.index++
+	default:
+		lexer.append('\\')
+	}
+	return hookLexContinue
+}
+
+func (lexer *hookShellLexer) consumeUnquoted() hookLexStep {
+	char := lexer.command[lexer.index]
+	switch char {
+	case '\'', '"':
+		lexer.started = true
+		lexer.inSingle = char == '\''
+		lexer.inDouble = char == '"'
+	case '\\':
+		return lexer.consumeUnquotedEscape()
+	case '$', '`', '(', ')':
+		return hookLexInvalid
+	case '<':
+		return lexer.consumeInputRedirect()
+	case '>':
+		return lexer.consumeOutputRedirect()
+	case '\n':
+		if len(lexer.argv) == 0 && !lexer.started && lexer.redirectTarget == hookRedirectNone {
+			return hookLexContinue
+		}
+		return lexer.stopCommand()
+	case '|', '&', ';':
+		return lexer.stopCommand()
+	default:
+		return lexer.consumePlain(char)
+	}
+	return hookLexContinue
+}
+
+func (lexer *hookShellLexer) stopCommand() hookLexStep {
+	lexer.emit()
+	if lexer.redirectTarget != hookRedirectNone {
+		return hookLexInvalid
+	}
+	return hookLexStop
+}
+
+func (lexer *hookShellLexer) consumeUnquotedEscape() hookLexStep {
+	if lexer.index+1 >= len(lexer.command) {
+		return hookLexInvalid
+	}
+	next := lexer.command[lexer.index+1]
+	if next != '\n' {
+		lexer.append(next)
+	}
+	lexer.index++
+	return hookLexContinue
+}
+
+func (lexer *hookShellLexer) consumeOutputRedirect() hookLexStep {
+	if lexer.redirectTarget != hookRedirectNone {
+		return hookLexInvalid
+	}
+	if lexer.started && allHookDigits(lexer.word.String()) {
+		lexer.discardWord()
+	} else {
+		lexer.emit()
+	}
+	if lexer.index+1 < len(lexer.command) && lexer.command[lexer.index+1] == '>' {
+		lexer.index++
+	}
+	if lexer.index+1 < len(lexer.command) && (lexer.command[lexer.index+1] == '&' || lexer.command[lexer.index+1] == '|') {
+		lexer.index++
+	}
+	lexer.redirectTarget = hookRedirectOutput
+	return hookLexContinue
+}
+
+func (lexer *hookShellLexer) consumeInputRedirect() hookLexStep {
+	if lexer.redirectTarget != hookRedirectNone {
+		return hookLexInvalid
+	}
+	if lexer.index+1 < len(lexer.command) {
+		next := lexer.command[lexer.index+1]
+		if next == '<' || next == '&' || next == '>' {
+			return hookLexInvalid
+		}
+	}
+	lexer.recordInput = true
+	if lexer.started && allHookDigits(lexer.word.String()) {
+		lexer.recordInput = allHookZeros(lexer.word.String())
+		lexer.discardWord()
+	} else {
+		lexer.emit()
+	}
+	lexer.redirectTarget = hookRedirectInput
+	return hookLexContinue
+}
+
+func (lexer *hookShellLexer) consumePlain(char byte) hookLexStep {
+	if unicode.IsSpace(rune(char)) {
+		lexer.emit()
+		return hookLexContinue
+	}
+	if char == '#' && !lexer.started {
+		return lexer.consumeComment()
+	}
+	lexer.append(char)
+	return hookLexContinue
+}
+
+func (lexer *hookShellLexer) consumeComment() hookLexStep {
+	if len(lexer.argv) > 0 || lexer.redirectTarget != hookRedirectNone {
+		return hookLexStop
+	}
+	for lexer.index+1 < len(lexer.command) && lexer.command[lexer.index+1] != '\n' {
+		lexer.index++
+	}
+	return hookLexContinue
+}
+
+func (lexer *hookShellLexer) append(char byte) {
+	lexer.word.WriteByte(char)
+	lexer.started = true
+}
+
+func (lexer *hookShellLexer) emit() {
+	if !lexer.started {
+		return
+	}
+	switch lexer.redirectTarget {
+	case hookRedirectInput:
+		if lexer.recordInput {
+			lexer.inputPaths = append(lexer.inputPaths, lexer.word.String())
+		}
+		lexer.recordInput = false
+		lexer.redirectTarget = hookRedirectNone
+	case hookRedirectOutput:
+		lexer.redirectTarget = hookRedirectNone
+	default:
+		lexer.argv = append(lexer.argv, lexer.word.String())
+	}
+	lexer.discardWord()
+}
+
+func (lexer *hookShellLexer) discardWord() {
+	lexer.word.Reset()
+	lexer.started = false
+}
+
+func (lexer *hookShellLexer) finish() ([]string, []string, bool) {
+	if lexer.inSingle || lexer.inDouble {
+		return nil, nil, false
+	}
+	lexer.emit()
+	if lexer.redirectTarget != hookRedirectNone {
+		return nil, nil, false
+	}
+	return lexer.argv, lexer.inputPaths, len(lexer.argv) > 0
+}
+
+func allHookDigits(value string) bool {
+	if value == "" {
+		return false
+	}
+	for _, char := range value {
+		if char < '0' || char > '9' {
+			return false
+		}
+	}
+	return true
+}
+
+func allHookZeros(value string) bool {
+	if value == "" {
+		return false
+	}
+	for _, char := range value {
+		if char != '0' {
+			return false
+		}
+	}
+	return true
+}
+
+func parseHookSearchInvocation(argv []string) (hookSearchInvocation, bool) {
+	if len(argv) < 2 {
+		return hookSearchInvocation{}, false
+	}
+
+	invocation := hookSearchInvocation{}
+	switch argv[0] {
+	case "grep":
+		invocation.tool = hookToolGrep
+		invocation.mode = hookPatternBRE
+	case "rg":
+		invocation.tool = hookToolRipgrep
+		invocation.mode = hookPatternERE
+	default:
+		return hookSearchInvocation{}, false
+	}
+
+	var operands []string
+	options := true
+	for index := 1; index < len(argv); index++ {
+		argument := argv[index]
+		if options && argument == "--" {
+			options = false
+			continue
+		}
+		if options && strings.HasPrefix(argument, "--") {
+			if !parseHookLongOption(&invocation, argument, argv, &index) {
+				return hookSearchInvocation{}, false
+			}
+			continue
+		}
+		if options && strings.HasPrefix(argument, "-") && argument != "-" {
+			if !parseHookShortOptions(&invocation, argument, argv, &index) {
+				return hookSearchInvocation{}, false
+			}
+			continue
+		}
+		operands = append(operands, argument)
+	}
+
+	if invocation.explicitPattern {
+		invocation.paths = operands
+	} else {
+		if len(operands) == 0 {
+			return hookSearchInvocation{}, false
+		}
+		invocation.patterns = append(invocation.patterns, operands[0])
+		invocation.paths = operands[1:]
+	}
+	return invocation, len(invocation.patterns) > 0
+}
+
+type hookOptionKind uint8
+
+const (
+	hookOptionUnknown hookOptionKind = iota
+	hookOptionTerminal
+	hookOptionFailOpen
+	hookOptionFlag
+	hookOptionOptionalValue
+	hookOptionValue
+	hookOptionDirectories
+	hookOptionPattern
+	hookOptionPatternFile
+	hookOptionInclude
+	hookOptionInsensitiveInclude
+	hookOptionExclude
+	hookOptionIncludeType
+	hookOptionExcludeType
+	hookOptionBRE
+	hookOptionERE
+	hookOptionFixed
+	hookOptionRecursive
+	hookOptionGlobInsensitive
+	hookOptionGlobSensitive
+)
+
+// The option inventory is intentionally fail-open for classification: an
+// unknown option makes the steering hook allow the command rather than guess
+// its operand arity. Keep these tables aligned with supported grep/rg releases.
+var hookCommonLongOptions = map[string]hookOptionKind{
+	"after-context":  hookOptionValue,
+	"before-context": hookOptionValue,
+	"context":        hookOptionValue,
+	"file":           hookOptionPatternFile,
+	"fixed-strings":  hookOptionFixed,
+	"help":           hookOptionTerminal,
+	"max-count":      hookOptionValue,
+	"regexp":         hookOptionPattern,
+	"version":        hookOptionTerminal,
+}
+
+var hookGrepLongOptions = map[string]hookOptionKind{
+	"basic-regexp":          hookOptionBRE,
+	"binary":                hookOptionFlag,
+	"binary-files":          hookOptionValue,
+	"byte-offset":           hookOptionFlag,
+	"count":                 hookOptionFlag,
+	"color":                 hookOptionOptionalValue,
+	"colour":                hookOptionOptionalValue,
+	"dereference-recursive": hookOptionRecursive,
+	"devices":               hookOptionValue,
+	"directories":           hookOptionDirectories,
+	"exclude":               hookOptionExclude,
+	"exclude-dir":           hookOptionValue,
+	"exclude-from":          hookOptionPatternFile,
+	"extended-regexp":       hookOptionERE,
+	"files-with-matches":    hookOptionFlag,
+	"files-without-match":   hookOptionFlag,
+	"group-separator":       hookOptionValue,
+	"ignore-case":           hookOptionFlag,
+	"include":               hookOptionInclude,
+	"initial-tab":           hookOptionFlag,
+	"invert-match":          hookOptionFlag,
+	"label":                 hookOptionValue,
+	"line-buffered":         hookOptionFlag,
+	"line-number":           hookOptionFlag,
+	"line-regexp":           hookOptionFlag,
+	"no-filename":           hookOptionFlag,
+	"no-group-separator":    hookOptionFlag,
+	"no-ignore-case":        hookOptionFlag,
+	"no-messages":           hookOptionFlag,
+	"null":                  hookOptionFlag,
+	"null-data":             hookOptionFlag,
+	"only-matching":         hookOptionFlag,
+	"perl-regexp":           hookOptionERE,
+	"quiet":                 hookOptionFlag,
+	"recursive":             hookOptionRecursive,
+	"silent":                hookOptionFlag,
+	"text":                  hookOptionFlag,
+	"with-filename":         hookOptionFlag,
+	"word-regexp":           hookOptionFlag,
+}
+
+var hookRipgrepLongOptions = map[string]hookOptionKind{
+	"auto-hybrid-regex":            hookOptionFlag,
+	"binary":                       hookOptionFlag,
+	"block-buffered":               hookOptionFlag,
+	"byte-offset":                  hookOptionFlag,
+	"case-sensitive":               hookOptionFlag,
+	"column":                       hookOptionFlag,
+	"color":                        hookOptionValue,
+	"context-separator":            hookOptionValue,
+	"count":                        hookOptionFlag,
+	"count-matches":                hookOptionFlag,
+	"crlf":                         hookOptionFlag,
+	"debug":                        hookOptionFlag,
+	"dfa-size-limit":               hookOptionValue,
+	"encoding":                     hookOptionValue,
+	"engine":                       hookOptionValue,
+	"field-context-separator":      hookOptionValue,
+	"field-match-separator":        hookOptionValue,
+	"files":                        hookOptionTerminal,
+	"files-with-matches":           hookOptionFlag,
+	"files-without-match":          hookOptionFlag,
+	"follow":                       hookOptionFlag,
+	"generate":                     hookOptionTerminal,
+	"glob":                         hookOptionInclude,
+	"glob-case-insensitive":        hookOptionGlobInsensitive,
+	"heading":                      hookOptionFlag,
+	"hidden":                       hookOptionFlag,
+	"hostname-bin":                 hookOptionValue,
+	"hyperlink-format":             hookOptionValue,
+	"iglob":                        hookOptionInsensitiveInclude,
+	"ignore-case":                  hookOptionFlag,
+	"ignore-file":                  hookOptionValue,
+	"ignore-file-case-insensitive": hookOptionFlag,
+	"include-zero":                 hookOptionFlag,
+	"invert-match":                 hookOptionFlag,
+	"json":                         hookOptionFlag,
+	"line-number":                  hookOptionFlag,
+	"line-regexp":                  hookOptionFlag,
+	"line-buffered":                hookOptionFlag,
+	"max-columns":                  hookOptionValue,
+	"max-columns-preview":          hookOptionFlag,
+	"max-depth":                    hookOptionValue,
+	"max-filesize":                 hookOptionValue,
+	"messages":                     hookOptionFlag,
+	"mmap":                         hookOptionFlag,
+	"multiline":                    hookOptionFlag,
+	"multiline-dotall":             hookOptionFlag,
+	"no-config":                    hookOptionFlag,
+	"no-context-separator":         hookOptionFlag,
+	"no-auto-hybrid-regex":         hookOptionFlag,
+	"no-fixed-strings":             hookOptionERE,
+	"no-filename":                  hookOptionFlag,
+	"no-glob-case-insensitive":     hookOptionGlobSensitive,
+	"no-heading":                   hookOptionFlag,
+	"no-ignore":                    hookOptionFlag,
+	"no-ignore-dot":                hookOptionFlag,
+	"no-ignore-exclude":            hookOptionFlag,
+	"no-ignore-files":              hookOptionFlag,
+	"no-ignore-global":             hookOptionFlag,
+	"no-ignore-messages":           hookOptionFlag,
+	"no-ignore-parent":             hookOptionFlag,
+	"no-ignore-vcs":                hookOptionFlag,
+	"no-line-number":               hookOptionFlag,
+	"no-messages":                  hookOptionFlag,
+	"no-mmap":                      hookOptionFlag,
+	"no-pcre2":                     hookOptionFlag,
+	"no-pcre2-unicode":             hookOptionFlag,
+	"no-require-git":               hookOptionFlag,
+	"no-unicode":                   hookOptionFlag,
+	"null":                         hookOptionFlag,
+	"null-data":                    hookOptionFlag,
+	"one-file-system":              hookOptionFlag,
+	"only-matching":                hookOptionFlag,
+	"passthru":                     hookOptionFlag,
+	"passthrough":                  hookOptionFlag,
+	"path-separator":               hookOptionValue,
+	"pcre2":                        hookOptionFlag,
+	"pcre2-unicode":                hookOptionFlag,
+	"pcre2-version":                hookOptionTerminal,
+	"pre":                          hookOptionValue,
+	"pre-glob":                     hookOptionValue,
+	"pretty":                       hookOptionFlag,
+	"quiet":                        hookOptionFlag,
+	"regex-size-limit":             hookOptionValue,
+	"replace":                      hookOptionValue,
+	"search-zip":                   hookOptionFlag,
+	"smart-case":                   hookOptionFlag,
+	"sort":                         hookOptionValue,
+	"sort-files":                   hookOptionFlag,
+	"sortr":                        hookOptionValue,
+	"stats":                        hookOptionFlag,
+	"stop-on-nonmatch":             hookOptionFlag,
+	"text":                         hookOptionFlag,
+	"threads":                      hookOptionValue,
+	"trace":                        hookOptionFlag,
+	"trim":                         hookOptionFlag,
+	"type":                         hookOptionIncludeType,
+	"type-add":                     hookOptionFailOpen,
+	"type-clear":                   hookOptionFailOpen,
+	"type-not":                     hookOptionExcludeType,
+	"type-list":                    hookOptionTerminal,
+	"unicode":                      hookOptionFlag,
+	"unrestricted":                 hookOptionFlag,
+	"vimgrep":                      hookOptionFlag,
+	"with-filename":                hookOptionFlag,
+	"word-regexp":                  hookOptionFlag,
+	"colors":                       hookOptionValue,
+}
+
+var hookGrepShortOptions = map[byte]hookOptionKind{
+	'A': hookOptionValue, 'B': hookOptionValue, 'C': hookOptionValue,
+	'D': hookOptionValue, 'd': hookOptionDirectories, 'm': hookOptionValue,
+	'E': hookOptionERE, 'P': hookOptionERE, 'F': hookOptionFixed, 'G': hookOptionBRE,
+	'R': hookOptionRecursive, 'r': hookOptionRecursive,
+	'e': hookOptionPattern, 'f': hookOptionPatternFile,
+	'V': hookOptionTerminal,
+}
+
+var hookRipgrepShortOptions = map[byte]hookOptionKind{
+	'A': hookOptionValue, 'B': hookOptionValue, 'C': hookOptionValue,
+	'E': hookOptionValue, 'M': hookOptionValue, 'd': hookOptionValue,
+	'j': hookOptionValue, 'm': hookOptionValue, 'r': hookOptionValue,
+	'F': hookOptionFixed, 'P': hookOptionFlag,
+	'e': hookOptionPattern, 'f': hookOptionPatternFile,
+	'g': hookOptionInclude, 't': hookOptionIncludeType, 'T': hookOptionExcludeType,
+	'h': hookOptionTerminal, 'V': hookOptionTerminal,
+}
+
+func parseHookLongOption(invocation *hookSearchInvocation, argument string, argv []string, index *int) bool {
+	nameValue := strings.TrimPrefix(argument, "--")
+	name, value, attached := strings.Cut(nameValue, "=")
+	kind := hookLongOptionKind(invocation.tool, name)
+	if kind == hookOptionUnknown {
+		return false
+	}
+	if kind == hookOptionPatternFile || kind == hookOptionTerminal || kind == hookOptionFailOpen {
+		return false
+	}
+	if !hookOptionNeedsValue(kind) {
+		if attached && kind != hookOptionOptionalValue {
+			return false
+		}
+		return applyHookFlagOption(invocation, kind)
+	}
+	if !attached {
+		if *index+1 >= len(argv) {
+			return false
+		}
+		(*index)++
+		value = argv[*index]
+	}
+	return applyHookValueOption(invocation, kind, value)
+}
+
+func hookOptionNeedsValue(kind hookOptionKind) bool {
+	switch kind {
+	case hookOptionValue, hookOptionDirectories, hookOptionPattern, hookOptionInclude, hookOptionInsensitiveInclude, hookOptionExclude,
+		hookOptionIncludeType, hookOptionExcludeType:
+		return true
+	default:
+		return false
+	}
+}
+
+func applyHookFlagOption(invocation *hookSearchInvocation, kind hookOptionKind) bool {
+	switch kind {
+	case hookOptionFlag, hookOptionOptionalValue:
+		return true
+	case hookOptionBRE:
+		invocation.mode = hookPatternBRE
+	case hookOptionERE:
+		invocation.mode = hookPatternERE
+	case hookOptionFixed:
+		invocation.mode = hookPatternFixed
+	case hookOptionRecursive:
+		invocation.recursive = true
+	case hookOptionGlobInsensitive:
+		invocation.globInsensitive = true
+	case hookOptionGlobSensitive:
+		invocation.globInsensitive = false
+	default:
+		return false
+	}
+	return true
+}
+
+func applyHookValueOption(invocation *hookSearchInvocation, kind hookOptionKind, value string) bool {
+	switch kind {
+	case hookOptionValue:
+		return true
+	case hookOptionDirectories:
+		invocation.recursive = strings.EqualFold(value, "recurse")
+	case hookOptionPattern:
+		invocation.patterns = append(invocation.patterns, value)
+		invocation.explicitPattern = true
+	case hookOptionInclude:
+		addHookInclude(invocation, value, false)
+	case hookOptionInsensitiveInclude:
+		addHookInclude(invocation, value, true)
+	case hookOptionExclude:
+		invocation.selectors = append(invocation.selectors, hookSelector{kind: hookSelectorExcludeGlob, value: value})
+	case hookOptionIncludeType:
+		invocation.selectors = append(invocation.selectors, hookSelector{kind: hookSelectorIncludeType, value: value})
+	case hookOptionExcludeType:
+		invocation.selectors = append(invocation.selectors, hookSelector{kind: hookSelectorExcludeType, value: value})
+	default:
+		return false
+	}
+	return true
+}
+
+func hookLongOptionKind(tool hookSearchTool, name string) hookOptionKind {
+	if kind, exists := hookCommonLongOptions[name]; exists {
+		return kind
+	}
+	if tool == hookToolGrep {
+		return hookGrepLongOptions[name]
+	}
+	return hookRipgrepLongOptions[name]
+}
+
+func parseHookShortOptions(invocation *hookSearchInvocation, argument string, argv []string, index *int) bool {
+	cluster := strings.TrimPrefix(argument, "-")
+	optionKinds := hookRipgrepShortOptions
+	flagOptions := ".0abchiHiIlLnNopqSsUuvwxz"
+	if invocation.tool == hookToolGrep {
+		optionKinds = hookGrepShortOptions
+		flagOptions = "0123456789abcHhIiJLlMnOopqSsTUuvwXxyZz"
+	}
+	for position := 0; position < len(cluster); position++ {
+		option := cluster[position]
+		remainder := cluster[position+1:]
+		kind, special := optionKinds[option]
+		if !special {
+			if !strings.ContainsRune(flagOptions, rune(option)) {
+				return false
+			}
+			continue
+		}
+		if kind == hookOptionPatternFile || kind == hookOptionTerminal || kind == hookOptionFailOpen {
+			return false
+		}
+		if !hookOptionNeedsValue(kind) {
+			if !applyHookFlagOption(invocation, kind) {
+				return false
+			}
+			continue
+		}
+		value, ok := hookShortOptionValue(remainder, argv, index)
+		if !ok {
+			return false
+		}
+		return applyHookValueOption(invocation, kind, value)
+	}
+	return true
+}
+
+func hookShortOptionValue(remainder string, argv []string, index *int) (string, bool) {
+	if remainder != "" {
+		return remainder, true
+	}
+	if *index+1 >= len(argv) {
+		return "", false
+	}
+	(*index)++
+	return argv[*index], true
+}
+
+func addHookInclude(invocation *hookSearchInvocation, value string, caseInsensitive bool) {
+	if invocation.tool == hookToolRipgrep && strings.HasPrefix(value, "!") {
+		invocation.selectors = append(invocation.selectors, hookSelector{
+			kind:            hookSelectorExcludeGlob,
+			value:           strings.TrimPrefix(value, "!"),
+			caseInsensitive: caseInsensitive,
+		})
+		return
+	}
+	invocation.selectors = append(invocation.selectors, hookSelector{
+		kind:            hookSelectorIncludeGlob,
+		value:           value,
+		caseInsensitive: caseInsensitive,
+	})
+}
+
+func hookSearchesGo(invocation hookSearchInvocation) bool {
+	if len(invocation.inputPaths) > 0 {
+		inputCanContainGo := hookPathCanContainGo(invocation.inputPaths[len(invocation.inputPaths)-1])
+		if hookHasStdinPath(invocation.paths) && inputCanContainGo {
+			return true
+		}
+		if len(invocation.paths) == 0 && !(invocation.tool == hookToolGrep && invocation.recursive) {
+			return inputCanContainGo
+		}
+	}
+	if !hookPathsCanContainGo(invocation) {
+		return false
+	}
+	if invocation.tool == hookToolRipgrep && hookHasExplicitGoPath(invocation.paths) {
+		return true
+	}
+	return hookSelectorsCanSearchGo(invocation)
+}
+
+func hookHasStdinPath(paths []string) bool {
+	for _, path := range paths {
+		if path == "-" {
+			return true
+		}
+	}
+	return false
+}
+
+func hookPathsCanContainGo(invocation hookSearchInvocation) bool {
+	if len(invocation.paths) == 0 {
+		return invocation.tool == hookToolRipgrep || invocation.recursive
+	}
+	for _, path := range invocation.paths {
+		if hookPathCanContainGo(path) {
+			return true
+		}
+	}
+	return false
+}
+
+func hookPathCanContainGo(path string) bool {
+	if path == "-" || hookExemptPath(path) {
+		return false
+	}
+	if hookGoValue(path) {
+		return true
+	}
+	return !hookExplicitNonGoValue(path)
+}
+
+func hookSelectorsCanSearchGo(invocation hookSearchInvocation) bool {
+	if allowed, selected := hookGlobSelectorsCanSearchGo(invocation); selected {
+		return allowed
+	}
+	if allowed, selected := hookTypeSelectorsCanSearchGo(invocation.selectors); selected {
+		return allowed
+	}
+	return true
+}
+
+func hookGlobSelectorsCanSearchGo(invocation hookSearchInvocation) (bool, bool) {
+	allowed := true
+	positive := false
+	relevant := false
+	for _, selector := range invocation.selectors {
+		caseInsensitive := invocation.globInsensitive || selector.caseInsensitive
+		switch selector.kind {
+		case hookSelectorIncludeGlob:
+			if !positive {
+				allowed = false
+				positive = true
+			}
+			if hookGlobCanMatchGo(selector.value, caseInsensitive) {
+				allowed = true
+			}
+			relevant = true
+		case hookSelectorExcludeGlob:
+			if hookExcludesEveryGoFile(selector.value, caseInsensitive) {
+				allowed = false
+				relevant = true
+			}
+		}
+	}
+	return allowed, relevant
+}
+
+func hookTypeSelectorsCanSearchGo(selectors []hookSelector) (bool, bool) {
+	allowed := true
+	positive := false
+	relevant := false
+	for _, selector := range selectors {
+		switch selector.kind {
+		case hookSelectorIncludeType:
+			if !positive {
+				allowed = false
+				positive = true
+			}
+			if hookGoType(selector.value) {
+				allowed = true
+			}
+			relevant = true
+		case hookSelectorExcludeType:
+			if hookGoType(selector.value) {
+				allowed = false
+				relevant = true
+			}
+		}
+	}
+	return allowed, relevant
+}
+
+func hookGoType(value string) bool {
+	return strings.EqualFold(value, "go") || strings.EqualFold(value, "golang") || strings.EqualFold(value, "all")
+}
+
+func hookHasExplicitGoPath(paths []string) bool {
+	for _, path := range paths {
+		if hookGoValue(path) {
+			return true
+		}
+	}
+	return false
+}
+
+func hookExemptPath(value string) bool {
+	normalized := strings.ReplaceAll(strings.ToLower(value), "\\", "/")
+	for strings.HasPrefix(normalized, "./") {
+		normalized = strings.TrimPrefix(normalized, "./")
+	}
+	normalized = strings.Trim(normalized, "/")
+	for _, part := range strings.Split(normalized, "/") {
+		switch part {
+		case "docs", ".github", "testdata", "migrations":
+			return true
+		}
+	}
+	return false
+}
+
+func hookExplicitNonGoValue(value string) bool {
+	lower := strings.ToLower(strings.TrimSpace(value))
+	for _, extension := range []string{
+		".go", ".yaml", ".yml", ".json", ".md", ".sh", ".toml", ".env", ".sql", ".txt",
+		".html", ".css", ".js", ".ts", ".py", ".rb", ".java", ".c", ".cpp", ".h", ".rs", ".tmp",
+	} {
+		if strings.HasSuffix(lower, extension) {
+			return true
+		}
+	}
+	return false
+}
+
+func hookGoValue(value string) bool {
+	return hookGoValuePattern.MatchString(value)
+}
+
+func hookGlobCanMatchGo(value string, caseInsensitive bool) bool {
+	if caseInsensitive {
+		value = strings.ToLower(value)
+	}
+	if hookGoValue(value) {
+		return true
+	}
+	if hookGoValue(strings.ToLower(value)) {
+		return false
+	}
+	return !hookExplicitNonGoValue(value)
+}
+
+func hookExcludesEveryGoFile(value string, caseInsensitive bool) bool {
+	normalized := strings.TrimSpace(value)
+	if caseInsensitive {
+		normalized = strings.ToLower(normalized)
+	}
+	if normalized == "*.go" || normalized == "**/*.go" || normalized == "**.go" {
+		return true
+	}
+	for _, prefix := range []string{"*.{", "**/*.{", "**.{"} {
+		if strings.HasPrefix(normalized, prefix) && strings.HasSuffix(normalized, "}") {
+			extensions := strings.Split(strings.TrimSuffix(strings.TrimPrefix(normalized, prefix), "}"), ",")
+			for _, extension := range extensions {
+				if extension == "go" {
+					return true
+				}
+			}
+		}
+	}
+	return false
+}
+
+func hookSymbolExempt(symbol string) bool {
+	lower := strings.ToLower(symbol)
+	if _, exists := hookCommentMarkers[lower]; exists {
+		return true
+	}
+	_, keyword := hookGoKeywords[symbol]
+	return keyword
+}
+
+func pureHookSymbolAlternatives(pattern string, mode hookPatternMode) ([]string, bool) {
+	switch mode {
+	case hookPatternFixed:
+		if hookIdentifierPattern.MatchString(pattern) {
+			return []string{pattern}, true
+		}
+		return nil, false
+	case hookPatternBRE:
+		return parseHookBREExpression(pattern)
+	case hookPatternERE:
+		return parseHookEREExpression(pattern)
+	default:
+		return nil, false
+	}
+}
+
+func parseHookEREExpression(expression string) ([]string, bool) {
+	for {
+		inner, wrapped, valid := unwrapHookEREGroup(expression)
+		if !valid {
+			return nil, false
+		}
+		if !wrapped {
+			break
+		}
+		expression = inner
+	}
+
+	parts, valid := splitHookEREAlternatives(expression)
+	if !valid {
+		return nil, false
+	}
+	if len(parts) == 1 {
+		if hookIdentifierPattern.MatchString(expression) {
+			return []string{expression}, true
+		}
+		return nil, false
+	}
+	return parseHookAlternativeParts(parts, parseHookEREExpression)
+}
+
+func unwrapHookEREGroup(expression string) (string, bool, bool) {
+	if !strings.HasPrefix(expression, "(") {
+		return expression, false, true
+	}
+	innerStart := 1
+	if strings.HasPrefix(expression, "(?:") {
+		innerStart = 3
+	} else if strings.HasPrefix(expression, "(?") {
+		return "", false, false
+	}
+
+	depth := 0
+	for index := 0; index < len(expression); index++ {
+		switch expression[index] {
+		case '\\':
+			if index+1 >= len(expression) {
+				return "", false, false
+			}
+			index++
+		case '(':
+			depth++
+		case ')':
+			depth--
+			if depth < 0 {
+				return "", false, false
+			}
+			if depth == 0 {
+				if index != len(expression)-1 {
+					return expression, false, true
+				}
+				return expression[innerStart:index], true, true
+			}
+		}
+	}
+	return "", false, false
+}
+
+func splitHookEREAlternatives(expression string) ([]string, bool) {
+	depth := 0
+	start := 0
+	parts := make([]string, 0, 2)
+	for index := 0; index < len(expression); index++ {
+		switch expression[index] {
+		case '\\':
+			if index+1 >= len(expression) {
+				return nil, false
+			}
+			index++
+		case '(':
+			depth++
+		case ')':
+			depth--
+			if depth < 0 {
+				return nil, false
+			}
+		case '|':
+			if depth == 0 {
+				parts = append(parts, expression[start:index])
+				start = index + 1
+			}
+		}
+	}
+	if depth != 0 {
+		return nil, false
+	}
+	parts = append(parts, expression[start:])
+	return parts, true
+}
+
+func parseHookBREExpression(expression string) ([]string, bool) {
+	for {
+		inner, wrapped, valid := unwrapHookBREGroup(expression)
+		if !valid {
+			return nil, false
+		}
+		if !wrapped {
+			break
+		}
+		expression = inner
+	}
+
+	parts, valid := splitHookBREAlternatives(expression)
+	if !valid {
+		return nil, false
+	}
+	if len(parts) == 1 {
+		if hookIdentifierPattern.MatchString(expression) {
+			return []string{expression}, true
+		}
+		return nil, false
+	}
+	return parseHookAlternativeParts(parts, parseHookBREExpression)
+}
+
+func unwrapHookBREGroup(expression string) (string, bool, bool) {
+	if !strings.HasPrefix(expression, `\(`) {
+		return expression, false, true
+	}
+	depth := 0
+	for index := 0; index < len(expression); index++ {
+		if expression[index] != '\\' || index+1 >= len(expression) {
+			continue
+		}
+		next := expression[index+1]
+		switch next {
+		case '(':
+			depth++
+		case ')':
+			depth--
+			if depth < 0 {
+				return "", false, false
+			}
+			if depth == 0 {
+				if index+2 != len(expression) {
+					return expression, false, true
+				}
+				return expression[2:index], true, true
+			}
+		}
+		index++
+	}
+	return "", false, false
+}
+
+func splitHookBREAlternatives(expression string) ([]string, bool) {
+	depth := 0
+	start := 0
+	parts := make([]string, 0, 2)
+	for index := 0; index < len(expression); index++ {
+		if expression[index] != '\\' || index+1 >= len(expression) {
+			continue
+		}
+		next := expression[index+1]
+		switch next {
+		case '(':
+			depth++
+		case ')':
+			depth--
+			if depth < 0 {
+				return nil, false
+			}
+		case '|':
+			if depth == 0 {
+				parts = append(parts, expression[start:index])
+				start = index + 2
+			}
+		}
+		index++
+	}
+	if depth != 0 {
+		return nil, false
+	}
+	parts = append(parts, expression[start:])
+	return parts, true
+}
+
+func parseHookAlternativeParts(parts []string, parse func(string) ([]string, bool)) ([]string, bool) {
+	var symbols []string
+	for _, part := range parts {
+		if part == "" {
+			return nil, false
+		}
+		partSymbols, valid := parse(part)
+		if !valid {
+			return nil, false
+		}
+		symbols = append(symbols, partSymbols...)
+	}
+	return symbols, len(symbols) > 0
+}

--- a/internal/cli/hook_guard_parser.go
+++ b/internal/cli/hook_guard_parser.go
@@ -808,7 +808,7 @@ func hookSearchesGo(invocation hookSearchInvocation) bool {
 		if hookHasStdinPath(invocation.paths) && inputCanContainGo {
 			return true
 		}
-		if len(invocation.paths) == 0 && !(invocation.tool == hookToolGrep && invocation.recursive) {
+		if len(invocation.paths) == 0 && (invocation.tool != hookToolGrep || !invocation.recursive) {
 			return inputCanContainGo
 		}
 	}

--- a/internal/cli/hook_guard_test.go
+++ b/internal/cli/hook_guard_test.go
@@ -1,0 +1,795 @@
+package cli
+
+import (
+	"bytes"
+	"fmt"
+	"slices"
+	"strings"
+	"testing"
+)
+
+func TestEvaluateHookCommandRegexAlternation(t *testing.T) {
+	tests := []struct {
+		name       string
+		command    string
+		wantExit   int
+		wantSymbol string
+	}{
+		{
+			name:       "grep BRE escaped alternation single quoted",
+			command:    `grep -rn 'runHookGuard\|evaluateHookCommand' internal/cli/*.go`,
+			wantExit:   2,
+			wantSymbol: "runHookGuard",
+		},
+		{
+			name:       "grep BRE escaped alternation double quoted",
+			command:    `grep -rn "runHookGuard\|hookGuardInput" internal/cli/*.go`,
+			wantExit:   2,
+			wantSymbol: "runHookGuard",
+		},
+		{
+			name:       "grep ERE bare alternation",
+			command:    `grep -Ern 'runHookGuard|evaluateHookCommand' --include='*.go' .`,
+			wantExit:   2,
+			wantSymbol: "runHookGuard",
+		},
+		{
+			name:       "grep long ERE flag bare alternation",
+			command:    `grep --extended-regexp -rn 'evaluateHookCommand|runHookGuard' --include='*.go' .`,
+			wantExit:   2,
+			wantSymbol: "evaluateHookCommand",
+		},
+		{
+			name:       "ripgrep bare alternation",
+			command:    `rg 'runHookGuard|evaluateHookCommand' -g '*.go' internal/cli`,
+			wantExit:   2,
+			wantSymbol: "runHookGuard",
+		},
+		{
+			name:       "ripgrep grouped alternation",
+			command:    `rg '(evaluateHookCommand|runHookGuard)' --glob '*.go' internal/cli`,
+			wantExit:   2,
+			wantSymbol: "evaluateHookCommand",
+		},
+		{
+			name:       "ripgrep noncapturing grouped alternation",
+			command:    `rg '(?:runHookGuard|evaluateHookCommand)' --glob='*.go' internal/cli`,
+			wantExit:   2,
+			wantSymbol: "runHookGuard",
+		},
+		{
+			name:     "grep BRE bare pipe is literal",
+			command:  `grep -rn 'runHookGuard|evaluateHookCommand' internal/cli/*.go`,
+			wantExit: 0,
+		},
+		{
+			name:     "grep fixed string literal pipe",
+			command:  `grep -Frn 'runHookGuard|evaluateHookCommand' internal/cli/*.go`,
+			wantExit: 0,
+		},
+		{
+			name:     "grep long fixed string escaped pipe",
+			command:  `grep --fixed-strings -rn 'runHookGuard\|evaluateHookCommand' internal/cli/*.go`,
+			wantExit: 0,
+		},
+		{
+			name:     "ripgrep fixed string literal pipe",
+			command:  `rg -F 'runHookGuard|evaluateHookCommand' -g '*.go' internal/cli`,
+			wantExit: 0,
+		},
+		{
+			name:     "ripgrep long fixed string literal pipe",
+			command:  `rg --fixed-strings 'runHookGuard|evaluateHookCommand' --glob '*.go' internal/cli`,
+			wantExit: 0,
+		},
+		{
+			name:     "ripgrep escaped pipe is literal",
+			command:  `rg 'runHookGuard\|evaluateHookCommand' -g '*.go' internal/cli`,
+			wantExit: 0,
+		},
+		{
+			name:     "grep BRE mixed symbol and non-symbol alternatives",
+			command:  `grep -rn 'runHookGuard\|error:.*' internal/cli/*.go`,
+			wantExit: 0,
+		},
+		{
+			name:     "grep ERE mixed symbol and non-symbol alternatives",
+			command:  `grep -Ern 'runHookGuard|error:.*' --include='*.go' .`,
+			wantExit: 0,
+		},
+		{
+			name:     "ripgrep mixed symbol and non-symbol alternatives",
+			command:  `rg '(runHookGuard|error:.*)' -g '*.go' internal/cli`,
+			wantExit: 0,
+		},
+		{
+			name:     "ripgrep mixed regexp flags",
+			command:  `rg -e runHookGuard -e 'error:.*' -g '*.go' internal/cli`,
+			wantExit: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assertHookGuardDecision(t, tt.command, tt.wantExit, tt.wantSymbol)
+		})
+	}
+}
+
+func TestEvaluateHookCommandPatternAndValueFlags(t *testing.T) {
+	tests := []struct {
+		name       string
+		command    string
+		wantSymbol string
+	}{
+		{
+			name:       "grep repeated short regexp flags",
+			command:    `grep -rn -e runHookGuard -e evaluateHookCommand --include='*.go' .`,
+			wantSymbol: "runHookGuard",
+		},
+		{
+			name:       "grep repeated long regexp flags",
+			command:    `grep -rn --regexp=runHookGuard --regexp hookGuardInput --include='*.go' .`,
+			wantSymbol: "runHookGuard",
+		},
+		{
+			name:       "ripgrep repeated short regexp flags",
+			command:    `rg -e runHookGuard -e evaluateHookCommand -g '*.go' .`,
+			wantSymbol: "runHookGuard",
+		},
+		{
+			name:       "ripgrep repeated long regexp flags",
+			command:    `rg --regexp=evaluateHookCommand --regexp runHookGuard --glob '*.go' .`,
+			wantSymbol: "evaluateHookCommand",
+		},
+		{
+			name:       "ripgrep short glob before pattern",
+			command:    `rg -g '*.go' runHookGuard .`,
+			wantSymbol: "runHookGuard",
+		},
+		{
+			name:       "ripgrep short glob after pattern",
+			command:    `rg runHookGuard -g '*.go' .`,
+			wantSymbol: "runHookGuard",
+		},
+		{
+			name:       "ripgrep long glob before pattern",
+			command:    `rg --glob '*.go' evaluateHookCommand .`,
+			wantSymbol: "evaluateHookCommand",
+		},
+		{
+			name:       "ripgrep long glob after pattern",
+			command:    `rg evaluateHookCommand --glob='*.go' .`,
+			wantSymbol: "evaluateHookCommand",
+		},
+		{
+			name:       "grep separated context value",
+			command:    `grep -rn -C 2 runHookGuard internal/cli/*.go`,
+			wantSymbol: "runHookGuard",
+		},
+		{
+			name:       "grep long context value",
+			command:    `grep -rn --context 2 evaluateHookCommand internal/cli/*.go`,
+			wantSymbol: "evaluateHookCommand",
+		},
+		{
+			name:       "ripgrep separated after-context value",
+			command:    `rg -n -A 2 runHookGuard -g '*.go' .`,
+			wantSymbol: "runHookGuard",
+		},
+		{
+			name:       "ripgrep inline before-context value",
+			command:    `rg -n --before-context=2 evaluateHookCommand --glob '*.go' .`,
+			wantSymbol: "evaluateHookCommand",
+		},
+		{
+			name:       "ripgrep byte offset flag",
+			command:    `rg -bn runHookGuard -g '*.go' internal/cli`,
+			wantSymbol: "runHookGuard",
+		},
+		{
+			name:       "ripgrep attached max depth",
+			command:    `rg -d2 evaluateHookCommand -g '*.go' .`,
+			wantSymbol: "evaluateHookCommand",
+		},
+		{
+			name:       "ripgrep separated max depth",
+			command:    `rg -d 2 runHookGuard -g '*.go' .`,
+			wantSymbol: "runHookGuard",
+		},
+		{
+			name:       "grep numeric context shorthand",
+			command:    `grep -2n 'runHookGuard\|evaluateHookCommand' internal/cli/*.go`,
+			wantSymbol: "runHookGuard",
+		},
+		{
+			name:       "ripgrep line-buffered pipeline search",
+			command:    `rg --line-buffered 'runHookGuard|evaluateHookCommand' -g '*.go' internal/cli`,
+			wantSymbol: "runHookGuard",
+		},
+		{
+			name:       "ripgrep pretty output alias",
+			command:    `rg --pretty 'runHookGuard|evaluateHookCommand' -g '*.go' internal/cli`,
+			wantSymbol: "runHookGuard",
+		},
+		{
+			name:       "ripgrep passthrough output alias",
+			command:    `rg --passthrough 'runHookGuard|evaluateHookCommand' -g '*.go' internal/cli`,
+			wantSymbol: "runHookGuard",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assertHookGuardDecision(t, tt.command, 2, tt.wantSymbol)
+		})
+	}
+}
+
+func TestEvaluateHookCommandDistinguishesRegexPipesFromShellPipelines(t *testing.T) {
+	tests := []struct {
+		name       string
+		command    string
+		wantExit   int
+		wantSymbol string
+	}{
+		{
+			name:       "BRE alternation followed by shell pipeline",
+			command:    `grep -rn 'runHookGuard\|evaluateHookCommand' internal/cli/*.go | head -1`,
+			wantExit:   2,
+			wantSymbol: "runHookGuard",
+		},
+		{
+			name:       "ERE alternation followed by shell pipeline",
+			command:    `grep -Ern 'evaluateHookCommand|runHookGuard' internal/cli/*.go | sed -n '1p'`,
+			wantExit:   2,
+			wantSymbol: "evaluateHookCommand",
+		},
+		{
+			name:       "identifier search followed by ripgrep pipeline",
+			command:    `grep -rn runHookGuard internal/cli/*.go | rg evaluateHookCommand`,
+			wantExit:   2,
+			wantSymbol: "runHookGuard",
+		},
+		{
+			name:     "fixed literal pipe followed by shell pipeline",
+			command:  `grep -Frn 'runHookGuard|evaluateHookCommand' internal/cli/*.go | head -1`,
+			wantExit: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assertHookGuardDecision(t, tt.command, tt.wantExit, tt.wantSymbol)
+		})
+	}
+}
+
+func TestEvaluateHookCommandDirectCommandScope(t *testing.T) {
+	// The hook is a workflow-steering aid, not a shell security boundary. Its
+	// documented policy applies to direct grep/rg Bash commands; shell wrappers
+	// and commands whose first program is not grep/rg remain out of scope.
+	tests := []struct {
+		name       string
+		command    string
+		wantExit   int
+		wantSymbol string
+	}{
+		{
+			name:       "direct grep",
+			command:    `grep -rn runHookGuard internal/cli/*.go`,
+			wantExit:   2,
+			wantSymbol: "runHookGuard",
+		},
+		{
+			name:       "direct ripgrep with leading whitespace",
+			command:    `  rg evaluateHookCommand -g '*.go' .`,
+			wantExit:   2,
+			wantSymbol: "evaluateHookCommand",
+		},
+		{
+			name:     "command wrapper is out of scope",
+			command:  `command grep -rn runHookGuard internal/cli/*.go`,
+			wantExit: 0,
+		},
+		{
+			name:     "environment wrapper is out of scope",
+			command:  `env rg runHookGuard -g '*.go' .`,
+			wantExit: 0,
+		},
+		{
+			name:     "shell wrapper is out of scope",
+			command:  `sh -c "grep -rn runHookGuard internal/cli/*.go"`,
+			wantExit: 0,
+		},
+		{
+			name:     "grep later in pipeline is out of scope",
+			command:  `printf '%s\n' runHookGuard | grep runHookGuard`,
+			wantExit: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assertHookGuardDecision(t, tt.command, tt.wantExit, tt.wantSymbol)
+		})
+	}
+}
+
+func TestEvaluateHookCommandFailOpenAndScope(t *testing.T) {
+	tests := []struct {
+		name       string
+		command    string
+		wantExit   int
+		wantSymbol string
+	}{
+		{
+			name:     "grep ERE escaped pipe is literal",
+			command:  `grep -Ern 'runHookGuard\|evaluateHookCommand' internal/cli/*.go`,
+			wantExit: 0,
+		},
+		{
+			name:       "shell escaped ripgrep alternation",
+			command:    `rg runHookGuard\|evaluateHookCommand -g '*.go' internal/cli`,
+			wantExit:   2,
+			wantSymbol: "runHookGuard",
+		},
+		{
+			name:       "output redirection is not a non-Go target",
+			command:    `rg runHookGuard -g '*.go' . > report.md`,
+			wantExit:   2,
+			wantSymbol: "runHookGuard",
+		},
+		{
+			name:     "quoted greater-than remains regex text",
+			command:  `rg 'runHookGuard>evaluateHookCommand' -g '*.go' .`,
+			wantExit: 0,
+		},
+		{
+			name:     "explicit non-Go file",
+			command:  `rg runHookGuard README.md`,
+			wantExit: 0,
+		},
+		{
+			name:     "explicit exempt directory",
+			command:  `rg runHookGuard .github/workflows`,
+			wantExit: 0,
+		},
+		{
+			name:       "mixed Go and non-Go globs still cover Go",
+			command:    `rg runHookGuard -g '*.go' -g '*.md' .`,
+			wantExit:   2,
+			wantSymbol: "runHookGuard",
+		},
+		{
+			name:       "mixed Go and non-Go paths still cover Go",
+			command:    `rg evaluateHookCommand internal/cli README.md`,
+			wantExit:   2,
+			wantSymbol: "evaluateHookCommand",
+		},
+		{
+			name:       "exempt path cannot poison a Go path",
+			command:    `rg runHookGuard docs internal/cli`,
+			wantExit:   2,
+			wantSymbol: "runHookGuard",
+		},
+		{
+			name:     "glob excludes every Go file",
+			command:  `rg runHookGuard -g '!*.go' .`,
+			wantExit: 0,
+		},
+		{
+			name:     "unknown option fails open",
+			command:  `rg --future-option runHookGuard .`,
+			wantExit: 0,
+		},
+		{
+			name:     "pattern file fails open",
+			command:  `rg -f patterns.txt .`,
+			wantExit: 0,
+		},
+		{
+			name:     "unclosed quote fails open",
+			command:  `rg 'runHookGuard -g '*.go' .`,
+			wantExit: 0,
+		},
+		{
+			name:     "dynamic expansion fails open",
+			command:  `rg "$PATTERN" -g '*.go' .`,
+			wantExit: 0,
+		},
+		{
+			name:     "non-recursive grep on stdin",
+			command:  `grep runHookGuard`,
+			wantExit: 0,
+		},
+		{
+			name:       "recursive grep is broad",
+			command:    `grep --recursive runHookGuard .`,
+			wantExit:   2,
+			wantSymbol: "runHookGuard",
+		},
+		{
+			name:       "grep filename flag preserves BRE alternation",
+			command:    `grep -Hrn 'runHookGuard\|evaluateHookCommand' internal/cli/*.go`,
+			wantExit:   2,
+			wantSymbol: "runHookGuard",
+		},
+		{
+			name:       "grep directory recursion mode is broad",
+			command:    `grep -d recurse 'runHookGuard\|evaluateHookCommand' .`,
+			wantExit:   2,
+			wantSymbol: "runHookGuard",
+		},
+		{
+			name:       "grep exclude-dir does not exclude Go files",
+			command:    `grep -r --exclude-dir='*.go' 'runHookGuard\|evaluateHookCommand' internal/cli`,
+			wantExit:   2,
+			wantSymbol: "runHookGuard",
+		},
+		{
+			name:       "ripgrep no-fixed-strings restores alternation",
+			command:    `rg --no-fixed-strings 'runHookGuard|evaluateHookCommand' -g '*.go' .`,
+			wantExit:   2,
+			wantSymbol: "runHookGuard",
+		},
+		{
+			name:       "exempt alternative cannot poison a symbol",
+			command:    `rg 'TODO|runHookGuard' -g '*.go' internal/cli`,
+			wantExit:   2,
+			wantSymbol: "runHookGuard",
+		},
+		{
+			name:       "exempt repeated pattern cannot poison a symbol",
+			command:    `rg -e TODO -e evaluateHookCommand -g '*.go' internal/cli`,
+			wantExit:   2,
+			wantSymbol: "evaluateHookCommand",
+		},
+		{
+			name:     "comment marker remains allowed",
+			command:  `rg TODO -g '*.go' .`,
+			wantExit: 0,
+		},
+		{
+			name:     "ripgrep files mode is not a pattern search",
+			command:  `rg --files runHookGuard`,
+			wantExit: 0,
+		},
+		{
+			name:     "help mode is not a pattern search",
+			command:  `rg --help runHookGuard`,
+			wantExit: 0,
+		},
+		{
+			name:     "Go keyword remains allowed",
+			command:  `rg type -g '*.go' .`,
+			wantExit: 0,
+		},
+		{
+			name:       "fixed mode still blocks separate symbol patterns",
+			command:    `rg -F -e runHookGuard -e evaluateHookCommand -g '*.go' .`,
+			wantExit:   2,
+			wantSymbol: "runHookGuard",
+		},
+		{
+			name:       "attached grep regexp preserves BRE alternation",
+			command:    `grep -rn --regexp='runHookGuard\|evaluateHookCommand' --include='*.go' .`,
+			wantExit:   2,
+			wantSymbol: "runHookGuard",
+		},
+		{
+			name:       "grep input redirection exposes Go target",
+			command:    `grep -n 'runHookGuard\|evaluateHookCommand' < internal/cli/hook_guard.go`,
+			wantExit:   2,
+			wantSymbol: "runHookGuard",
+		},
+		{
+			name:       "ripgrep input redirection exposes Go target",
+			command:    `rg 'evaluateHookCommand|runHookGuard' < internal/cli/hook_guard.go`,
+			wantExit:   2,
+			wantSymbol: "evaluateHookCommand",
+		},
+		{
+			name:       "explicit stdin descriptor exposes Go target",
+			command:    `grep -n 'runHookGuard\|evaluateHookCommand' 0<internal/cli/hook_guard.go`,
+			wantExit:   2,
+			wantSymbol: "runHookGuard",
+		},
+		{
+			name:       "unrelated file descriptor does not replace recursive scope",
+			command:    `grep -rl 'runHookGuard\|evaluateHookCommand' 3<README.md`,
+			wantExit:   2,
+			wantSymbol: "runHookGuard",
+		},
+		{
+			name:       "stdin redirection does not replace recursive grep scope",
+			command:    `grep -rl 'runHookGuard\|evaluateHookCommand' < README.md`,
+			wantExit:   2,
+			wantSymbol: "runHookGuard",
+		},
+		{
+			name:       "stdin operand uses redirected Go target",
+			command:    `grep -n 'runHookGuard\|evaluateHookCommand' - < internal/cli/hook_guard.go`,
+			wantExit:   2,
+			wantSymbol: "runHookGuard",
+		},
+		{
+			name:       "mixed stdin operand uses redirected Go target",
+			command:    `rg 'evaluateHookCommand|runHookGuard' README.md - < internal/cli/hook_guard.go`,
+			wantExit:   2,
+			wantSymbol: "evaluateHookCommand",
+		},
+		{
+			name:       "leading blank line finds first command",
+			command:    "\nrg 'runHookGuard|evaluateHookCommand' -g '*.go' internal/cli",
+			wantExit:   2,
+			wantSymbol: "runHookGuard",
+		},
+		{
+			name:       "leading comment finds first command",
+			command:    "# inspect symbols\nrg 'runHookGuard|evaluateHookCommand' -g '*.go' internal/cli",
+			wantExit:   2,
+			wantSymbol: "runHookGuard",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assertHookGuardDecision(t, tt.command, tt.wantExit, tt.wantSymbol)
+		})
+	}
+}
+
+func TestEvaluateHookCommandModeAndSelectionOrdering(t *testing.T) {
+	tests := []struct {
+		name       string
+		command    string
+		wantExit   int
+		wantSymbol string
+	}{
+		{
+			name:     "ripgrep PCRE engine keeps fixed-string mode",
+			command:  `rg -F -P 'runHookGuard|evaluateHookCommand' -g '*.go' internal/cli`,
+			wantExit: 0,
+		},
+		{
+			name:     "ripgrep long PCRE engine keeps fixed-string mode",
+			command:  `rg --pcre2 -F 'runHookGuard|evaluateHookCommand' -g '*.go' internal/cli`,
+			wantExit: 0,
+		},
+		{
+			name:     "ripgrep disabling PCRE keeps fixed-string mode",
+			command:  `rg -F --no-pcre2 'runHookGuard|evaluateHookCommand' -g '*.go' internal/cli`,
+			wantExit: 0,
+		},
+		{
+			name:     "ripgrep color consumes its separate value",
+			command:  `rg --color always 'error:.*' internal/cli/hook_guard.go`,
+			wantExit: 0,
+		},
+		{
+			name:       "grep color accepts an attached value",
+			command:    `grep --color=always -rn 'runHookGuard\|evaluateHookCommand' internal/cli/*.go`,
+			wantExit:   2,
+			wantSymbol: "runHookGuard",
+		},
+		{
+			name:       "later ripgrep Go include wins",
+			command:    `rg 'runHookGuard|evaluateHookCommand' -g '!*.go' -g '*.go' internal/cli`,
+			wantExit:   2,
+			wantSymbol: "runHookGuard",
+		},
+		{
+			name:     "later ripgrep Go exclusion wins",
+			command:  `rg 'runHookGuard|evaluateHookCommand' -g '*.go' -g '!*.go' internal/cli`,
+			wantExit: 0,
+		},
+		{
+			name:       "later ripgrep Go type include wins",
+			command:    `rg 'runHookGuard|evaluateHookCommand' -Tgo -tgo internal/cli`,
+			wantExit:   2,
+			wantSymbol: "runHookGuard",
+		},
+		{
+			name:     "later ripgrep Go type exclusion wins",
+			command:  `rg 'runHookGuard|evaluateHookCommand' -tgo -Tgo internal/cli`,
+			wantExit: 0,
+		},
+		{
+			name:       "ripgrep all type includes Go",
+			command:    `rg 'runHookGuard|evaluateHookCommand' -tall internal/cli`,
+			wantExit:   2,
+			wantSymbol: "runHookGuard",
+		},
+		{
+			name:     "ripgrep all type excludes Go",
+			command:  `rg 'runHookGuard|evaluateHookCommand' -Tall internal/cli`,
+			wantExit: 0,
+		},
+		{
+			name:       "later ripgrep all type re-includes Go",
+			command:    `rg 'runHookGuard|evaluateHookCommand' -Tgo -tall internal/cli`,
+			wantExit:   2,
+			wantSymbol: "runHookGuard",
+		},
+		{
+			name:     "negated brace glob excludes Go",
+			command:  `rg 'runHookGuard|evaluateHookCommand' -g '!*.{go,md}' internal/cli`,
+			wantExit: 0,
+		},
+		{
+			name:     "later negated brace glob excludes Go",
+			command:  `rg 'runHookGuard|evaluateHookCommand' -g '*.go' -g '!*.{go,md}' internal/cli`,
+			wantExit: 0,
+		},
+		{
+			name:       "later Go include wins after brace exclusion",
+			command:    `rg 'runHookGuard|evaluateHookCommand' -g '!*.{go,md}' -g '*.go' internal/cli`,
+			wantExit:   2,
+			wantSymbol: "runHookGuard",
+		},
+		{
+			name:       "case-sensitive uppercase exclusion keeps lowercase Go",
+			command:    `rg 'runHookGuard|evaluateHookCommand' -g '!*.GO' internal/cli`,
+			wantExit:   2,
+			wantSymbol: "runHookGuard",
+		},
+		{
+			name:       "case-sensitive uppercase brace exclusion keeps lowercase Go",
+			command:    `rg 'runHookGuard|evaluateHookCommand' -g '!*.{GO,md}' internal/cli`,
+			wantExit:   2,
+			wantSymbol: "runHookGuard",
+		},
+		{
+			name:     "case-insensitive iglob excludes Go",
+			command:  `rg 'runHookGuard|evaluateHookCommand' --iglob '!*.GO' internal/cli`,
+			wantExit: 0,
+		},
+		{
+			name:     "global case-insensitive glob excludes Go",
+			command:  `rg 'runHookGuard|evaluateHookCommand' --glob-case-insensitive -g '!*.GO' internal/cli`,
+			wantExit: 0,
+		},
+		{
+			name:       "explicit case-sensitive glob mode keeps Go",
+			command:    `rg 'runHookGuard|evaluateHookCommand' --no-glob-case-insensitive -g '!*.GO' internal/cli`,
+			wantExit:   2,
+			wantSymbol: "runHookGuard",
+		},
+		{
+			name:       "later case-sensitive toggle wins",
+			command:    `rg 'runHookGuard|evaluateHookCommand' --glob-case-insensitive -g '!*.GO' --no-glob-case-insensitive internal/cli`,
+			wantExit:   2,
+			wantSymbol: "runHookGuard",
+		},
+		{
+			name:     "case-sensitive uppercase include omits lowercase Go",
+			command:  `rg 'runHookGuard|evaluateHookCommand' -g '*.GO' internal/cli`,
+			wantExit: 0,
+		},
+		{
+			name:       "later grep Go include wins",
+			command:    `grep -r --exclude='*.go' --include='*.go' 'runHookGuard\|evaluateHookCommand' internal/cli`,
+			wantExit:   2,
+			wantSymbol: "runHookGuard",
+		},
+		{
+			name:     "later grep Go exclusion wins",
+			command:  `grep -r --include='*.go' --exclude='*.go' 'runHookGuard\|evaluateHookCommand' internal/cli`,
+			wantExit: 0,
+		},
+		{
+			name:     "grep exclusion file is dynamic",
+			command:  `grep -r --exclude-from=patterns.txt 'runHookGuard\|evaluateHookCommand' internal/cli`,
+			wantExit: 0,
+		},
+		{
+			name:     "ripgrep custom type definition fails open",
+			command:  `rg --type-add 'foo:*.go' -tfoo 'runHookGuard|evaluateHookCommand' internal/cli`,
+			wantExit: 0,
+		},
+		{
+			name:     "invalid ripgrep include option fails open",
+			command:  `rg --include='*.go' 'runHookGuard|evaluateHookCommand' internal/cli`,
+			wantExit: 0,
+		},
+		{
+			name:       "Go glob under dot-prefixed directory",
+			command:    `rg 'runHookGuard|evaluateHookCommand' .config/pkg/*.go`,
+			wantExit:   2,
+			wantSymbol: "runHookGuard",
+		},
+		{
+			name:       "Go path containing non-Go extension text",
+			command:    `rg 'runHookGuard|evaluateHookCommand' foo.corpus/hook_guard.md.go`,
+			wantExit:   2,
+			wantSymbol: "runHookGuard",
+		},
+		{
+			name:     "Go-looking temporary file is non-Go",
+			command:  `rg 'runHookGuard|evaluateHookCommand' hook_guard.go.tmp`,
+			wantExit: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assertHookGuardDecision(t, tt.command, tt.wantExit, tt.wantSymbol)
+		})
+	}
+}
+
+func TestClassifyHookCommandReturnsEveryAlternative(t *testing.T) {
+	tests := []struct {
+		name    string
+		command string
+		want    []string
+	}{
+		{
+			name:    "basic grep preserves and deduplicates branches",
+			command: `grep -rn 'runHookGuard\|evaluateHookCommand\|runHookGuard' internal/cli/*.go`,
+			want:    []string{"runHookGuard", "evaluateHookCommand"},
+		},
+		{
+			name:    "nested ripgrep alternatives preserve source order",
+			command: `rg '(runHookGuard|(?:evaluateHookCommand|runHookGuard))' -g '*.go' internal/cli`,
+			want:    []string{"runHookGuard", "evaluateHookCommand"},
+		},
+		{
+			name:    "exempt branch is omitted without hiding symbol",
+			command: `rg '(TODO|evaluateHookCommand)' -g '*.go' internal/cli`,
+			want:    []string{"evaluateHookCommand"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			decision := classifyHookCommand(tt.command)
+			if !decision.block {
+				t.Fatalf("classifyHookCommand(%q) did not block", tt.command)
+			}
+			if !slices.Equal(decision.symbols, tt.want) {
+				t.Fatalf("classifyHookCommand(%q) symbols = %q, want %q", tt.command, decision.symbols, tt.want)
+			}
+		})
+	}
+}
+
+func assertHookGuardDecision(t *testing.T, command string, wantExit int, wantSymbol string) {
+	t.Helper()
+
+	firstExit, firstOutput := evaluateHookCommandForTest(t, command)
+	secondExit, secondOutput := evaluateHookCommandForTest(t, command)
+	if firstExit != secondExit || firstOutput != secondOutput {
+		t.Fatalf("evaluateHookCommand(%q) is not deterministic:\nfirst: exit=%d output=%q\nsecond: exit=%d output=%q",
+			command, firstExit, firstOutput, secondExit, secondOutput)
+	}
+	if firstExit != wantExit {
+		t.Fatalf("evaluateHookCommand(%q) exit = %d, want %d\noutput:\n%s", command, firstExit, wantExit, firstOutput)
+	}
+
+	if wantExit == 0 {
+		if firstOutput != "" {
+			t.Fatalf("evaluateHookCommand(%q) allowed command but wrote output:\n%s", command, firstOutput)
+		}
+		return
+	}
+
+	if !strings.Contains(firstOutput, "gograph-guard: blocked grep") {
+		t.Fatalf("evaluateHookCommand(%q) did not explain the block:\n%s", command, firstOutput)
+	}
+	for _, tool := range []string{"query", "context", "callers", "impact"} {
+		wantSuggestion := fmt.Sprintf(`gograph_%s %q`, tool, wantSymbol)
+		if !strings.Contains(firstOutput, wantSuggestion) {
+			t.Errorf("evaluateHookCommand(%q) output missing deterministic suggestion %q:\n%s", command, wantSuggestion, firstOutput)
+		}
+	}
+}
+
+func evaluateHookCommandForTest(t *testing.T, command string) (int, string) {
+	t.Helper()
+
+	var output bytes.Buffer
+	exitCode := evaluateHookCommandTo(command, &output)
+	return exitCode, output.String()
+}

--- a/llm-wiki/log.md
+++ b/llm-wiki/log.md
@@ -253,3 +253,13 @@ Normalized the security-flow page link into the index's Schemas and Security sec
 - Added fail-closed validation for a single official fetch URL and single effective official push URL, exact metadata modes, detached HEAD, branch/HEAD races, preflight and concurrent remote divergence, feature-branch retries, and missing-tag recovery when remote `main` already contains the release commit.
 - Verified the repository's current topology (`agent/mcp-registry-publishing` ahead of `origin/main`) and confirmed the final full non-publishing release gate passes, including unit/race tests, vet, lint/static/security checks, six MCPBs, MCP smoke, docs, and GoReleaser snapshot.
 - No release commit, version tag, push, GitHub release, or Registry publication was created during this correction.
+## [2026-07-13] maintenance | Fix hook-guard alternation parsing
+
+- Fixed GitHub issue #27: basic-grep `\|` alternations now preserve every identifier while extended grep/ripgrep, literal pipes, fixed strings, and shell pipelines retain their real semantics.
+- Added a deterministic direct-command lexer/classifier with known option arity, ordered selectors, case toggles, and descriptor-aware redirection; unsupported dynamic syntax still fails open.
+- Added unit/E2E regressions for the reporter's command and updated maintained docs/release notes.
+- Verification passed: precise 133-file build, graph checks, full unit/race/lint/static/security suites, coverage, fuzzing, and Hugo.
+
+## [2026-07-13] maintenance | Close hook-guard log formatting
+
+- Consumed the governed append's trailing blank line as this entry's separator; no project facts changed.


### PR DESCRIPTION
## Summary

- parse direct grep and ripgrep commands with shell-aware, search-mode-aware alternation handling
- preserve every alternative while honoring options, selectors, redirections, and fail-open behavior for unsupported syntax
- add focused regression coverage for the exact issue report and update maintained integration documentation
- correct ordinary PR MCPB verification to use ephemeral candidate metadata while retaining strict committed-hash checks in the release workflow

## Root cause

The previous hook extracted only a single token using a regular expression. A quoted basic-grep pattern containing the BRE alternation operator \| was therefore treated as one invalid identifier instead of two protected symbols.

During CI, this source change also exposed a pre-existing workflow defect: candidate binaries were compared with immutable hashes for the already-published v1.5.1 assets. PR CI now verifies candidate bundles against temporary metadata generated from those exact artifacts; release verification remains unchanged and fail-closed against committed metadata.

## Validation

- full unit and end-to-end test suite
- race detector, vet, staticcheck, golangci-lint, govulncheck, and Grype
- coverage and fuzz targets
- precise self-analysis and Hugo documentation build
- all six MCPB bundles plus native MCP initialization
- GitHub Actions run https://github.com/ozgurcd/gograph/actions/runs/29308791305

Thanks @serdardalgic for the clear report and reproducible examples.

Closes #27