### PR TITLE
fix(scanner): honor effective Go build constraints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,8 @@
 bin/
 bin/gograph-test
 /gograph
-docs/ARCHITECTURAL_GUIDELINES.mdcoverage.out
+docs/ARCHITECTURAL_GUIDELINES.md
+coverage.out
 .release-mcpb/
 .release-work/
 dist/

--- a/README.md
+++ b/README.md
@@ -58,8 +58,9 @@ Build artifacts are written under the target `.gograph/` directory. `gograph`
 adds `.gograph/` to the enclosing Git repository root `.gitignore` when
 available, falls back to the build target `.gitignore` outside Git, and exits
 without replacing artifacts if no Go files are found or no source file parses
-successfully. Individual ignored files and ignored directories use the same
-scanner policy for building, freshness checks, and change detection.
+successfully. Go build constraints, cmd/go package-directory rules, generated
+sources, module-mode ignore directives, and Git ignores use the same scanner
+policy for building, freshness checks, and change detection.
 
 ## Why gograph?
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,23 @@
 
 ## Unreleased
 
+### Build-Context-Aware Repository Indexing
+
+- The AST scanner and precise package loader now share cmd/go's effective
+  build context, including modern and legacy build constraints, GOOS/GOARCH
+  filenames, cgo, release/tool tags, and custom tags inherited through
+  `GOFLAGS`. Inactive tooling files such as `//go:build ignore` no longer
+  pollute graph records or force repository-wide `precise_fallback`.
+- Scanner package discovery now matches `go list ./...` for hidden,
+  underscore-prefixed, `testdata`, and Go 1.26 module-mode ignore directories
+  while retaining nested-module coverage diagnostics and broken-source tolerance.
+- Graph freshness now compares the selected-file inventory and an additive
+  source-selection fingerprint, so deletions, active/inactive transitions,
+  nested module-boundary changes, and build-context changes trigger MCP
+  refresh instead of serving stale symbols.
+- Build-context resolution decodes stdout separately from successful cmd/go
+  stderr diagnostics, preserving precise analysis during toolchain messages.
+
 ### Official MCP Registry Distribution
 
 - Restored the maintainer's one-command patch-release workflow: after a

--- a/cmd/mcpb-release/main_test.go
+++ b/cmd/mcpb-release/main_test.go
@@ -260,7 +260,10 @@ func TestGitHubReleaseStateVerifiesDownloadedMCPBs(t *testing.T) {
 		t.Skip("cross-compiles the six published MCPB fixtures")
 	}
 	const version = "1.5.0"
-	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
+	// Cold CI runners cross-compile all six targets while other package tests
+	// may be doing the same work. Keep a hard bound without making 3 minutes a
+	// hidden performance requirement for release-fixture verification.
+	ctx, cancel := context.WithTimeout(context.Background(), 8*time.Minute)
 	defer cancel()
 	fixture := newPublishedReleaseFixture(t, ctx, version)
 

--- a/docs-site/content/docs/command-reference.md
+++ b/docs-site/content/docs/command-reference.md
@@ -16,7 +16,7 @@ gograph build [path] [--precise]
 ```
 Walks and parses a Go repository. Generates the structured graph at `.gograph/graph.json` and nine targeted Markdown reports in `.gograph/`.
 Adds `.gograph/` to the Git repository root `.gitignore` when available; outside Git, falls back to the build target `.gitignore`.
-Git-ignored files and directories use the same exclusion policy in `build`, `stale`, and `changes`. If no Go files are found or none parse successfully, exits without replacing existing artifacts. Partial parse failures are recorded in `graph.json`, which is committed with an atomic rename.
+The scanner honors the effective Go build context, including build tags, platform filenames, cgo, test-file constraints, cmd/go package-directory rules, and module ignore directives. Git-ignored files and directories use the same exclusion policy in `build`, `stale`, and `changes`. If no Go files are found or none parse successfully, exits without replacing existing artifacts. Partial parse failures are recorded in `graph.json`, which is committed with an atomic rename.
 - **Arguments**: `path` (optional, defaults to `.`)
 - **Flags**: 
   - `--precise`: Attempts type-checked CHA/SSA enrichment. Enrichment needs compilable, build-selected packages; on failure or an incomplete non-test package load gograph warns and still publishes the AST graph. Graph metadata records `precise`, `precise_fallback`, or `ast`. Precise interface calls retain one parallel call edge per valid named in-repository target; promoted methods add an explicitly marked traversal-only forwarding edge.
@@ -26,7 +26,7 @@ Git-ignored files and directories use the same exclusion policy in `build`, `sta
 ```bash
 gograph stale
 ```
-Checks if any `.go` source files in the repository are newer than `.gograph/graph.json`. Returns a list of files that have been modified since the last build.
+Compares the selected-file inventory, effective Go build context, and source modification times with `.gograph/graph.json`. It reports added, deleted, newly active, newly inactive, and modified selected files plus build-context changes.
 
 ### stats
 ```bash

--- a/docs-site/content/docs/getting-started.md
+++ b/docs-site/content/docs/getting-started.md
@@ -6,7 +6,7 @@ description: "Install gograph, build your first graph, and run your first querie
 
 ## Prerequisites
 
-- Go 1.26 or later
+- Go 1.26.5 or later
 - A Go module repository (`go.mod` present)
 
 ## Install
@@ -116,7 +116,7 @@ parse_failures: 0
 gograph stale
 ```
 
-Lists indexed source files that are newer than `graph.json`. It uses the same ignore policy as `build`, and all filesystem-backed commands resolve the repository root recorded in the graph, so it works identically from subdirectories. Rebuild if any files are listed.
+Compares the current selected-file inventory, effective Go build context, and source modification times with `graph.json`. It uses the same build-constraint and ignore policy as `build`, and all filesystem-backed commands resolve the repository root recorded in the graph, so it works identically from subdirectories. Rebuild when it reports any freshness change.
 
 ## Step 3 — Run repository-wide queries
 

--- a/docs-site/content/posts/analyzing-go-codebase-with-gograph.md
+++ b/docs-site/content/posts/analyzing-go-codebase-with-gograph.md
@@ -330,7 +330,7 @@ Install the static analysis utility using Homebrew:
 brew install ozgurcd/tap/gograph
 ```
 
-Alternatively, install directly from source (Go 1.26+):
+Alternatively, install directly from source (Go 1.26.5+):
 
 ```bash
 go install github.com/ozgurcd/gograph/cmd/gograph@latest

--- a/docs/coding-agent-usage.md
+++ b/docs/coding-agent-usage.md
@@ -49,7 +49,7 @@ gograph envs [term]             # list indexed environment reads
 gograph concurrency [term]      # map goroutines, channels, mutexes, waitgroups, sync.Once
 gograph tests [symbol]          # find which test functions exercise a named symbol
 gograph path <from> <to>        # shortest call chain between two symbols (BFS traversal)
-gograph stale                   # check if graph.json is out of date vs source files
+gograph stale                   # check selected files and build context vs graph.json
 gograph stats                   # compact index health summary: schema/build/precision status and package/file/symbol/call/route/SQL/env/test/flow-function counts
 gograph godobj                  # find god-object struct candidates (default thresholds)
 gograph godobj --methods 10 --fields 12 --calls 30 --top 5  # custom thresholds
@@ -250,7 +250,7 @@ from an HTTP handler to a SQL call without first reading every intermediate
 file. It does not prove that the path executes at runtime.
 
 ### 9. Graph freshness check
-`gograph stale` compares `graph.json`'s `generated_at` timestamp against files selected by the same scanner and Git-ignore rules as `build`. It displays the graph age, the newest source file, and its modification time. If any indexed source file is newer, it lists the changed files and tells the agent to re-run `gograph build .`. It uses the root recorded in `graph.json`, so results are identical from repository subdirectories. Agents should run this before any structural analysis.
+`gograph stale` compares the selected-file inventory, effective Go build context, and source modification times with the persisted graph. It detects added, deleted, newly inactive, and newly active source files even when timestamps alone cannot. It displays the graph age, the newest selected source file, changed files, and whether the build context changed, then tells the agent to re-run `gograph build .` when needed. It uses the root recorded in `graph.json`, so results are identical from repository subdirectories. Agents should run this before any structural analysis.
 
 ### 10. Reading Internal Implementations (Mock Stubs, Algorithms)
 When you need to read an indexed method body (for example, to check whether a
@@ -787,7 +787,7 @@ so parallel MCP traffic never replaces process-global stdout.
 
 The current suite registers 65 MCP endpoints: 61 query, analysis, and workflow tools plus four session lifecycle tools. The live `gograph_capabilities` payload is tested against the server registry.
 - **`gograph_capabilities`**: Discover available tools and workflows.
-- **`gograph_stale`**: Check whether `.gograph/graph.json` is outdated relative to Go source files. Returns JSON with `is_stale`, `graph_age`, `newest_source_mtime`, `newest_source_file`, and `changed_files[]`.
+- **`gograph_stale`**: Check whether `.gograph/graph.json` is outdated relative to selected Go source files or the effective build context. Returns JSON with `is_stale`, `graph_age`, `newest_source_mtime`, `newest_source_file`, `changed_files[]`, and `build_context_changed`.
 - **`gograph_session_create`**: Start a telemetry audit session for tracking agent compliance and tool success metrics.
 - **`gograph_session_end`**: End the active telemetry session cleanly and write end-of-session logs.
 - **`gograph_session_audit`**: Review and grade agent compliance (Plan rule, Review rule, Composability/Efficiency) and tool success rates.
@@ -968,7 +968,7 @@ gograph session cleanup
 - **Project metadata reads** — in addition to `.go` files, gograph reads `go.mod`, `.gitignore`, Git state, `.gograph/graph.json`, and user-selected gograph JSON/YAML configs, including `.gograph/flow.json`. It does not intentionally read `.env`, key, certificate, kubeconfig, or tfstate files.
 - **Targeted source output** — `source` and `context` return requested Go source, and inline route-handler bodies are stored in `graph.json` so endpoint analysis can return them. Other graph data is structural metadata.
 - **Generated files skipped** — `.pb.go`, `_generated.go`, files with `// Code generated` headers are excluded so they don't pollute the map.
-- **AI agent worktrees and ignored paths excluded** — `.claude/`, `.cursor/`, `.agents/` directories are skipped entirely, and both individual files and directories listed in `.gitignore` are excluded via `git check-ignore`. The same scanner policy powers build, stale, and changes.
+- **Inactive and ignored paths excluded** — Go build constraints, GOOS/GOARCH filenames, cgo state, cmd/go's hidden/underscore/`testdata` package-directory rules, Go 1.26 module ignore directives, generated sources, `.claude/`, `.cursor/`, `.agents/`, and Git-ignored paths are excluded consistently. The same scanner policy powers build, stale, and changes.
 - **Subdirectory aware** — all query commands auto-discover the project root by walking up to the nearest `.gograph/` directory. Agents do not need to `cd` back to the repo root before running `plan`, `review`, or any other query.
 - **Crash-safe graph publication** — output files are mode `0640`; `graph.json` is synced to a temporary file and atomically renamed, and the Git repository root `.gitignore` is appended to, never overwritten.
 

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.26.5
 require (
 	github.com/mark3labs/mcp-go v0.52.0
 	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2
+	golang.org/x/mod v0.36.0
 	golang.org/x/tools v0.45.0
 	gopkg.in/yaml.v3 v3.0.1
 )
@@ -14,7 +15,6 @@ require (
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/spf13/cast v1.7.1 // indirect
 	github.com/yosida95/uritemplate/v3 v3.0.2 // indirect
-	golang.org/x/mod v0.36.0 // indirect
 	golang.org/x/sync v0.20.0 // indirect
 	golang.org/x/text v0.14.0 // indirect
 )

--- a/internal/buildctx/buildctx.go
+++ b/internal/buildctx/buildctx.go
@@ -3,44 +3,116 @@
 package buildctx
 
 import (
+	"bytes"
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"go/build"
 	"os"
 	"os/exec"
+	"path/filepath"
+	"sort"
 	"strings"
+
+	"golang.org/x/mod/modfile"
 )
 
 // Config is an immutable snapshot of the file-selection inputs used by both
 // go/build and go/packages. Callers should use Environment and Flags, which
 // return defensive copies, when configuring subprocess-backed package loads.
 type Config struct {
-	build       build.Context
-	environment []string
-	buildFlags  []string
+	build          build.Context
+	environment    []string
+	buildFlags     []string
+	modulesEnabled bool
+	moduleRoot     string
+	modulePath     string
 }
 
 // Resolve asks cmd/go for its effective build context. This deliberately lets
 // the Go tool interpret GOENV, GOFLAGS, toolchain selection, cgo defaults, and
 // tool/release tags instead of duplicating those rules in gograph.
 func Resolve(ctx context.Context, root string) (Config, error) {
-	environment := append([]string(nil), os.Environ()...)
-	cmd := exec.CommandContext(ctx, "go", "list", "-e", "-json=false", "-deps=false", "-test=false", "-export=false", "-find=false", "-f", goListContextTemplate, "builtin")
+	canonicalRoot, err := canonicalDirectory(root)
+	if err != nil {
+		return Config{}, fmt.Errorf("resolve Go build root: %w", err)
+	}
+	// os.Getwd accepts PWD as its lexical spelling when it names the current
+	// directory. Pin both cmd.Dir and PWD to the canonical root so cmd/go does
+	// not discover a different GOMOD merely because gograph was invoked from
+	// inside rather than outside a symlinked scan root.
+	environment := setEnvironmentValue(os.Environ(), "PWD", canonicalRoot)
+	return resolve(ctx, canonicalRoot, environment, runGoCommand)
+}
+
+// ResolveOrDefault returns the effective Go context when cmd/go is available,
+// or a usable build.Default snapshot together with the resolution error. AST
+// callers can remain tolerant while precise callers retain the error.
+func ResolveOrDefault(ctx context.Context, root string) (Config, error) {
+	config, err := Resolve(ctx, root)
+	if err == nil {
+		return config, nil
+	}
+	return FromBuildContext(build.Default, os.Environ()), err
+}
+
+type goCommandRunner func(context.Context, string, []string, ...string) (stdout, stderr []byte, err error)
+
+func runGoCommand(ctx context.Context, root string, environment []string, args ...string) ([]byte, []byte, error) {
+	cmd := exec.CommandContext(ctx, "go", args...)
 	cmd.Dir = root
 	cmd.Env = environment
-	out, err := cmd.CombinedOutput()
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	stdout, err := cmd.Output()
+	return stdout, stderr.Bytes(), err
+}
+
+func resolve(ctx context.Context, root string, environment []string, run goCommandRunner) (Config, error) {
+	stdout, stderr, err := run(ctx, root, environment,
+		"list", "-e", "-json=false", "-deps=false", "-test=false", "-export=false", "-find=false", "-f", goListContextTemplate, "builtin",
+	)
 	if err != nil {
-		message := strings.TrimSpace(string(out))
-		if message == "" {
-			return Config{}, fmt.Errorf("resolve Go build context: %w", err)
-		}
-		return Config{}, fmt.Errorf("resolve Go build context: %w: %s", err, message)
+		return Config{}, commandError("resolve Go build context", stdout, stderr, err)
 	}
 
 	var resolved wireContext
-	if err := json.Unmarshal(out, &resolved); err != nil {
+	if err := json.Unmarshal(stdout, &resolved); err != nil {
 		return Config{}, fmt.Errorf("decode Go build context: %w", err)
+	}
+	if resolved.GOOS == "" || resolved.GOARCH == "" || resolved.Compiler == "" {
+		return Config{}, fmt.Errorf("decode Go build context: missing GOOS, GOARCH, or compiler")
+	}
+
+	moduleStdout, moduleStderr, err := run(ctx, root, environment, "env", "-json", "GO111MODULE", "GOMOD")
+	if err != nil {
+		return Config{}, commandError("resolve Go module context", moduleStdout, moduleStderr, err)
+	}
+	var moduleContext wireModuleContext
+	if err := json.Unmarshal(moduleStdout, &moduleContext); err != nil {
+		return Config{}, fmt.Errorf("decode Go module context: %w", err)
+	}
+	moduleRoot := ""
+	modulePath := ""
+	if moduleContext.GOMOD != "" && filepath.Clean(moduleContext.GOMOD) != filepath.Clean(os.DevNull) {
+		// Cmd/go defines the module root from the directory entry named by
+		// GOMOD, even when go.mod itself is a symlink to a file elsewhere.
+		// Canonicalize directory aliases without replacing that final entry.
+		canonicalModuleRoot, canonicalErr := canonicalDirectory(filepath.Dir(moduleContext.GOMOD))
+		if canonicalErr != nil {
+			return Config{}, fmt.Errorf("resolve main module identity: %w", canonicalErr)
+		}
+		moduleRoot = canonicalModuleRoot
+		data, readErr := os.ReadFile(moduleContext.GOMOD)
+		if readErr != nil {
+			return Config{}, fmt.Errorf("read main module identity: %w", readErr)
+		}
+		modulePath = modfile.ModulePath(data)
+		if modulePath == "" {
+			return Config{}, fmt.Errorf("read main module identity: %s has no module path", moduleContext.GOMOD)
+		}
 	}
 
 	buildContext := build.Default
@@ -49,18 +121,45 @@ func Resolve(ctx context.Context, root string) (Config, error) {
 	buildContext.CgoEnabled = resolved.CgoEnabled
 	buildContext.UseAllFiles = resolved.UseAllFiles
 	buildContext.Compiler = resolved.Compiler
+	buildContext.GOROOT = resolved.GOROOT
+	buildContext.GOPATH = resolved.GOPATH
 	buildContext.BuildTags = append([]string(nil), resolved.BuildTags...)
 	buildContext.ToolTags = append([]string(nil), resolved.ToolTags...)
 	buildContext.ReleaseTags = append([]string(nil), resolved.ReleaseTags...)
 	buildContext.InstallSuffix = resolved.InstallSuffix
 
-	return FromBuildContext(buildContext, environment), nil
+	return fromBuildContext(buildContext, environment, moduleContext.GO111MODULE != "off", moduleRoot, modulePath), nil
+}
+
+func commandError(prefix string, stdout, stderr []byte, err error) error {
+	message := strings.TrimSpace(string(stderr))
+	if message == "" {
+		message = strings.TrimSpace(string(stdout))
+	}
+	if message == "" {
+		return fmt.Errorf("%s: %w", prefix, err)
+	}
+	return fmt.Errorf("%s: %w: %s", prefix, err, message)
 }
 
 // FromBuildContext creates a deterministic configuration from an injected
 // go/build context. It is primarily useful for host-independent tests and as
 // the AST fallback when cmd/go cannot resolve the target repository.
 func FromBuildContext(buildContext build.Context, environment []string) Config {
+	return fromBuildContext(buildContext, environment, false, "", "")
+}
+
+// FromBuildContextWithModule creates an injected configuration with explicit
+// module-mode state. It is intended for deterministic scanner tests.
+func FromBuildContextWithModule(buildContext build.Context, environment []string, modulesEnabled bool, moduleRoot string) Config {
+	modulePath := ""
+	if data, err := os.ReadFile(filepath.Join(moduleRoot, "go.mod")); err == nil {
+		modulePath = modfile.ModulePath(data)
+	}
+	return fromBuildContext(buildContext, environment, modulesEnabled, moduleRoot, modulePath)
+}
+
+func fromBuildContext(buildContext build.Context, environment []string, modulesEnabled bool, moduleRoot, modulePath string) Config {
 	cgoEnabled := "0"
 	if buildContext.CgoEnabled {
 		cgoEnabled = "1"
@@ -70,10 +169,15 @@ func FromBuildContext(buildContext build.Context, environment []string) Config {
 		"GOOS="+buildContext.GOOS,
 		"GOARCH="+buildContext.GOARCH,
 		"CGO_ENABLED="+cgoEnabled,
+		"GOROOT="+buildContext.GOROOT,
+		"GOPATH="+buildContext.GOPATH,
 	)
 	return Config{
-		build:       cloneBuildContext(buildContext),
-		environment: env,
+		build:          cloneBuildContext(buildContext),
+		environment:    env,
+		modulesEnabled: modulesEnabled,
+		moduleRoot:     cleanOptionalPath(moduleRoot),
+		modulePath:     modulePath,
 		// An explicit flag is applied after GOFLAGS by cmd/go. Pinning the
 		// already-resolved tags prevents scanner and loader interpretations
 		// from diverging while preserving all other inherited GOFLAGS.
@@ -96,6 +200,115 @@ func (c Config) Flags() []string {
 	return append([]string(nil), c.buildFlags...)
 }
 
+// ModulesEnabled reports whether cmd/go is operating in module-aware mode.
+func (c Config) ModulesEnabled() bool {
+	return c.modulesEnabled
+}
+
+// ModuleRoot returns the effective main-module root, or an empty string when
+// the build target is not inside a main module.
+func (c Config) ModuleRoot() string {
+	return c.moduleRoot
+}
+
+// ModulePath returns the main module's declared import path, or an empty
+// string when the build target is outside module mode.
+func (c Config) ModulePath() string {
+	return c.modulePath
+}
+
+// Fingerprint identifies the effective inputs that can change Go source-file
+// selection. It deliberately excludes the full environment because that can
+// contain secrets and unrelated volatile values.
+func (c Config) Fingerprint() string {
+	ctx := c.BuildContext()
+	buildTags := sortedCopy(ctx.BuildTags)
+	toolTags := sortedCopy(ctx.ToolTags)
+	releaseTags := sortedCopy(ctx.ReleaseTags)
+	payload, err := json.Marshal(struct {
+		Version        int      `json:"version"`
+		GOOS           string   `json:"goos"`
+		GOARCH         string   `json:"goarch"`
+		CgoEnabled     bool     `json:"cgo_enabled"`
+		UseAllFiles    bool     `json:"use_all_files"`
+		Compiler       string   `json:"compiler"`
+		GOROOT         string   `json:"goroot"`
+		GOPATH         string   `json:"gopath"`
+		InstallSuffix  string   `json:"install_suffix"`
+		BuildTags      []string `json:"build_tags"`
+		ToolTags       []string `json:"tool_tags"`
+		ReleaseTags    []string `json:"release_tags"`
+		ModulesEnabled bool     `json:"modules_enabled"`
+		ModuleRoot     string   `json:"module_root"`
+		ModulePath     string   `json:"module_path"`
+	}{
+		Version:        4,
+		GOOS:           ctx.GOOS,
+		GOARCH:         ctx.GOARCH,
+		CgoEnabled:     ctx.CgoEnabled,
+		UseAllFiles:    ctx.UseAllFiles,
+		Compiler:       ctx.Compiler,
+		GOROOT:         ctx.GOROOT,
+		GOPATH:         ctx.GOPATH,
+		InstallSuffix:  ctx.InstallSuffix,
+		BuildTags:      buildTags,
+		ToolTags:       toolTags,
+		ReleaseTags:    releaseTags,
+		ModulesEnabled: c.ModulesEnabled(),
+		ModuleRoot:     c.ModuleRoot(),
+		ModulePath:     c.ModulePath(),
+	})
+	if err != nil {
+		return ""
+	}
+	sum := sha256.Sum256(payload)
+	return hex.EncodeToString(sum[:])
+}
+
+func sortedCopy(values []string) []string {
+	copyOfValues := make([]string, len(values))
+	copy(copyOfValues, values)
+	sort.Strings(copyOfValues)
+	return copyOfValues
+}
+
+func cleanOptionalPath(path string) string {
+	if path == "" {
+		return ""
+	}
+	return filepath.Clean(path)
+}
+
+func canonicalDirectory(path string) (string, error) {
+	absPath, err := filepath.Abs(path)
+	if err != nil {
+		return "", err
+	}
+	resolved, err := filepath.EvalSymlinks(absPath)
+	if err != nil {
+		return "", err
+	}
+	info, err := os.Stat(resolved)
+	if err != nil {
+		return "", err
+	}
+	if !info.IsDir() {
+		return "", fmt.Errorf("%s is not a directory", path)
+	}
+	return filepath.Clean(resolved), nil
+}
+
+func setEnvironmentValue(environment []string, key, value string) []string {
+	prefix := key + "="
+	result := make([]string, 0, len(environment)+1)
+	for _, entry := range environment {
+		if !strings.HasPrefix(entry, prefix) {
+			result = append(result, entry)
+		}
+	}
+	return append(result, prefix+value)
+}
+
 func cloneBuildContext(ctx build.Context) build.Context {
 	ctx.BuildTags = append([]string(nil), ctx.BuildTags...)
 	ctx.ToolTags = append([]string(nil), ctx.ToolTags...)
@@ -109,13 +322,20 @@ type wireContext struct {
 	CgoEnabled    bool     `json:"cgo_enabled"`
 	UseAllFiles   bool     `json:"use_all_files"`
 	Compiler      string   `json:"compiler"`
+	GOROOT        string   `json:"goroot"`
+	GOPATH        string   `json:"gopath"`
 	BuildTags     []string `json:"build_tags"`
 	ToolTags      []string `json:"tool_tags"`
 	ReleaseTags   []string `json:"release_tags"`
 	InstallSuffix string   `json:"install_suffix"`
 }
 
+type wireModuleContext struct {
+	GO111MODULE string `json:"GO111MODULE"`
+	GOMOD       string `json:"GOMOD"`
+}
+
 // cmd/go exposes its fully resolved build.Context to go-list templates. The
 // values interpolated here are restricted Go identifiers or booleans;
 // printf %q therefore produces valid JSON strings while retaining all tags.
-const goListContextTemplate = `{"goos":{{printf "%q" context.GOOS}},"goarch":{{printf "%q" context.GOARCH}},"cgo_enabled":{{context.CgoEnabled}},"use_all_files":{{context.UseAllFiles}},"compiler":{{printf "%q" context.Compiler}},"build_tags":[{{range $index, $tag := context.BuildTags}}{{if $index}},{{end}}{{printf "%q" $tag}}{{end}}],"tool_tags":[{{range $index, $tag := context.ToolTags}}{{if $index}},{{end}}{{printf "%q" $tag}}{{end}}],"release_tags":[{{range $index, $tag := context.ReleaseTags}}{{if $index}},{{end}}{{printf "%q" $tag}}{{end}}],"install_suffix":{{printf "%q" context.InstallSuffix}}}`
+const goListContextTemplate = `{"goos":{{printf "%q" context.GOOS}},"goarch":{{printf "%q" context.GOARCH}},"cgo_enabled":{{context.CgoEnabled}},"use_all_files":{{context.UseAllFiles}},"compiler":{{printf "%q" context.Compiler}},"goroot":{{printf "%q" context.GOROOT}},"gopath":{{printf "%q" context.GOPATH}},"build_tags":[{{range $index, $tag := context.BuildTags}}{{if $index}},{{end}}{{printf "%q" $tag}}{{end}}],"tool_tags":[{{range $index, $tag := context.ToolTags}}{{if $index}},{{end}}{{printf "%q" $tag}}{{end}}],"release_tags":[{{range $index, $tag := context.ReleaseTags}}{{if $index}},{{end}}{{printf "%q" $tag}}{{end}}],"install_suffix":{{printf "%q" context.InstallSuffix}}}`

--- a/internal/buildctx/buildctx.go
+++ b/internal/buildctx/buildctx.go
@@ -1,0 +1,121 @@
+// Package buildctx resolves the effective Go build configuration shared by
+// source scanning and type-checked package loading.
+package buildctx
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"go/build"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+// Config is an immutable snapshot of the file-selection inputs used by both
+// go/build and go/packages. Callers should use Environment and Flags, which
+// return defensive copies, when configuring subprocess-backed package loads.
+type Config struct {
+	build       build.Context
+	environment []string
+	buildFlags  []string
+}
+
+// Resolve asks cmd/go for its effective build context. This deliberately lets
+// the Go tool interpret GOENV, GOFLAGS, toolchain selection, cgo defaults, and
+// tool/release tags instead of duplicating those rules in gograph.
+func Resolve(ctx context.Context, root string) (Config, error) {
+	environment := append([]string(nil), os.Environ()...)
+	cmd := exec.CommandContext(ctx, "go", "list", "-e", "-json=false", "-deps=false", "-test=false", "-export=false", "-find=false", "-f", goListContextTemplate, "builtin")
+	cmd.Dir = root
+	cmd.Env = environment
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		message := strings.TrimSpace(string(out))
+		if message == "" {
+			return Config{}, fmt.Errorf("resolve Go build context: %w", err)
+		}
+		return Config{}, fmt.Errorf("resolve Go build context: %w: %s", err, message)
+	}
+
+	var resolved wireContext
+	if err := json.Unmarshal(out, &resolved); err != nil {
+		return Config{}, fmt.Errorf("decode Go build context: %w", err)
+	}
+
+	buildContext := build.Default
+	buildContext.GOOS = resolved.GOOS
+	buildContext.GOARCH = resolved.GOARCH
+	buildContext.CgoEnabled = resolved.CgoEnabled
+	buildContext.UseAllFiles = resolved.UseAllFiles
+	buildContext.Compiler = resolved.Compiler
+	buildContext.BuildTags = append([]string(nil), resolved.BuildTags...)
+	buildContext.ToolTags = append([]string(nil), resolved.ToolTags...)
+	buildContext.ReleaseTags = append([]string(nil), resolved.ReleaseTags...)
+	buildContext.InstallSuffix = resolved.InstallSuffix
+
+	return FromBuildContext(buildContext, environment), nil
+}
+
+// FromBuildContext creates a deterministic configuration from an injected
+// go/build context. It is primarily useful for host-independent tests and as
+// the AST fallback when cmd/go cannot resolve the target repository.
+func FromBuildContext(buildContext build.Context, environment []string) Config {
+	cgoEnabled := "0"
+	if buildContext.CgoEnabled {
+		cgoEnabled = "1"
+	}
+	env := append([]string(nil), environment...)
+	env = append(env,
+		"GOOS="+buildContext.GOOS,
+		"GOARCH="+buildContext.GOARCH,
+		"CGO_ENABLED="+cgoEnabled,
+	)
+	return Config{
+		build:       cloneBuildContext(buildContext),
+		environment: env,
+		// An explicit flag is applied after GOFLAGS by cmd/go. Pinning the
+		// already-resolved tags prevents scanner and loader interpretations
+		// from diverging while preserving all other inherited GOFLAGS.
+		buildFlags: []string{"-tags=" + strings.Join(buildContext.BuildTags, ",")},
+	}
+}
+
+// BuildContext returns a defensive copy of the resolved go/build context.
+func (c Config) BuildContext() build.Context {
+	return cloneBuildContext(c.build)
+}
+
+// Environment returns a defensive copy of the environment snapshot.
+func (c Config) Environment() []string {
+	return append([]string(nil), c.environment...)
+}
+
+// Flags returns a defensive copy of the package-loader build flags.
+func (c Config) Flags() []string {
+	return append([]string(nil), c.buildFlags...)
+}
+
+func cloneBuildContext(ctx build.Context) build.Context {
+	ctx.BuildTags = append([]string(nil), ctx.BuildTags...)
+	ctx.ToolTags = append([]string(nil), ctx.ToolTags...)
+	ctx.ReleaseTags = append([]string(nil), ctx.ReleaseTags...)
+	return ctx
+}
+
+type wireContext struct {
+	GOOS          string   `json:"goos"`
+	GOARCH        string   `json:"goarch"`
+	CgoEnabled    bool     `json:"cgo_enabled"`
+	UseAllFiles   bool     `json:"use_all_files"`
+	Compiler      string   `json:"compiler"`
+	BuildTags     []string `json:"build_tags"`
+	ToolTags      []string `json:"tool_tags"`
+	ReleaseTags   []string `json:"release_tags"`
+	InstallSuffix string   `json:"install_suffix"`
+}
+
+// cmd/go exposes its fully resolved build.Context to go-list templates. The
+// values interpolated here are restricted Go identifiers or booleans;
+// printf %q therefore produces valid JSON strings while retaining all tags.
+const goListContextTemplate = `{"goos":{{printf "%q" context.GOOS}},"goarch":{{printf "%q" context.GOARCH}},"cgo_enabled":{{context.CgoEnabled}},"use_all_files":{{context.UseAllFiles}},"compiler":{{printf "%q" context.Compiler}},"build_tags":[{{range $index, $tag := context.BuildTags}}{{if $index}},{{end}}{{printf "%q" $tag}}{{end}}],"tool_tags":[{{range $index, $tag := context.ToolTags}}{{if $index}},{{end}}{{printf "%q" $tag}}{{end}}],"release_tags":[{{range $index, $tag := context.ReleaseTags}}{{if $index}},{{end}}{{printf "%q" $tag}}{{end}}],"install_suffix":{{printf "%q" context.InstallSuffix}}}`

--- a/internal/buildctx/buildctx_test.go
+++ b/internal/buildctx/buildctx_test.go
@@ -1,0 +1,84 @@
+package buildctx
+
+import (
+	"context"
+	"go/build"
+	"os"
+	"path/filepath"
+	"reflect"
+	"slices"
+	"testing"
+)
+
+func TestResolveUsesEffectiveGoToolContext(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "go.mod"), []byte("module example.com/buildctx\n\ngo 1.26\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("GOENV", "off")
+	t.Setenv("GOWORK", "off")
+	t.Setenv("GOTOOLCHAIN", "local")
+	t.Setenv("GOOS", "linux")
+	t.Setenv("GOARCH", "amd64")
+	t.Setenv("CGO_ENABLED", "0")
+	t.Setenv("GOFLAGS", "-tags=issue30_custom,ignore")
+
+	config, err := Resolve(context.Background(), root)
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	buildContext := config.BuildContext()
+	if buildContext.GOOS != "linux" || buildContext.GOARCH != "amd64" || buildContext.CgoEnabled {
+		t.Fatalf("resolved target = %s/%s cgo=%v, want linux/amd64 cgo=false", buildContext.GOOS, buildContext.GOARCH, buildContext.CgoEnabled)
+	}
+	for _, tag := range []string{"issue30_custom", "ignore"} {
+		if !slices.Contains(buildContext.BuildTags, tag) {
+			t.Fatalf("resolved build tags %v do not contain %q", buildContext.BuildTags, tag)
+		}
+	}
+	if len(buildContext.ToolTags) == 0 || len(buildContext.ReleaseTags) == 0 {
+		t.Fatalf("tool/release tags were not resolved: tool=%v release=%v", buildContext.ToolTags, buildContext.ReleaseTags)
+	}
+	if want := []string{"-tags=issue30_custom,ignore"}; !reflect.DeepEqual(config.Flags(), want) {
+		t.Fatalf("Flags() = %v, want %v", config.Flags(), want)
+	}
+	if got := lastEnvironmentValue(config.Environment(), "CGO_ENABLED"); got != "0" {
+		t.Fatalf("CGO_ENABLED = %q, want 0", got)
+	}
+}
+
+func TestConfigAccessorsReturnDefensiveCopies(t *testing.T) {
+	config := FromBuildContext(buildContextFixture(), []string{"ORIGINAL=value"})
+	ctx := config.BuildContext()
+	ctx.BuildTags[0] = "mutated"
+	env := config.Environment()
+	env[0] = "MUTATED=value"
+	flags := config.Flags()
+	flags[0] = "-tags=mutated"
+
+	if got := config.BuildContext().BuildTags[0]; got != "original" {
+		t.Fatalf("BuildContext was mutated through accessor: %q", got)
+	}
+	if got := config.Environment()[0]; got != "ORIGINAL=value" {
+		t.Fatalf("Environment was mutated through accessor: %q", got)
+	}
+	if got := config.Flags()[0]; got != "-tags=original" {
+		t.Fatalf("Flags were mutated through accessor: %q", got)
+	}
+}
+
+func buildContextFixture() build.Context {
+	ctx := build.Default
+	ctx.BuildTags = []string{"original"}
+	return ctx
+}
+
+func lastEnvironmentValue(environment []string, key string) string {
+	prefix := key + "="
+	for i := len(environment) - 1; i >= 0; i-- {
+		if len(environment[i]) >= len(prefix) && environment[i][:len(prefix)] == prefix {
+			return environment[i][len(prefix):]
+		}
+	}
+	return ""
+}

--- a/internal/buildctx/buildctx_test.go
+++ b/internal/buildctx/buildctx_test.go
@@ -2,11 +2,13 @@ package buildctx
 
 import (
 	"context"
+	"errors"
 	"go/build"
 	"os"
 	"path/filepath"
 	"reflect"
 	"slices"
+	"strings"
 	"testing"
 )
 
@@ -18,6 +20,7 @@ func TestResolveUsesEffectiveGoToolContext(t *testing.T) {
 	t.Setenv("GOENV", "off")
 	t.Setenv("GOWORK", "off")
 	t.Setenv("GOTOOLCHAIN", "local")
+	t.Setenv("GO111MODULE", "")
 	t.Setenv("GOOS", "linux")
 	t.Setenv("GOARCH", "amd64")
 	t.Setenv("CGO_ENABLED", "0")
@@ -39,11 +42,103 @@ func TestResolveUsesEffectiveGoToolContext(t *testing.T) {
 	if len(buildContext.ToolTags) == 0 || len(buildContext.ReleaseTags) == 0 {
 		t.Fatalf("tool/release tags were not resolved: tool=%v release=%v", buildContext.ToolTags, buildContext.ReleaseTags)
 	}
+	if buildContext.GOROOT == "" || buildContext.GOPATH == "" {
+		t.Fatalf("Go roots were not resolved: GOROOT=%q GOPATH=%q", buildContext.GOROOT, buildContext.GOPATH)
+	}
 	if want := []string{"-tags=issue30_custom,ignore"}; !reflect.DeepEqual(config.Flags(), want) {
 		t.Fatalf("Flags() = %v, want %v", config.Flags(), want)
 	}
 	if got := lastEnvironmentValue(config.Environment(), "CGO_ENABLED"); got != "0" {
 		t.Fatalf("CGO_ENABLED = %q, want 0", got)
+	}
+	resolvedRootInfo, resolvedRootErr := os.Stat(config.ModuleRoot())
+	wantRootInfo, wantRootErr := os.Stat(root)
+	if !config.ModulesEnabled() || resolvedRootErr != nil || wantRootErr != nil || !os.SameFile(resolvedRootInfo, wantRootInfo) {
+		t.Fatalf("module context = enabled:%v root:%q, want enabled root equivalent to %q", config.ModulesEnabled(), config.ModuleRoot(), root)
+	}
+	if config.ModulePath() != "example.com/buildctx" {
+		t.Fatalf("module path = %q, want example.com/buildctx", config.ModulePath())
+	}
+}
+
+func TestResolveCanonicalizesSymlinkRootIndependentlyOfAmbientPWD(t *testing.T) {
+	realRoot := filepath.Join(t.TempDir(), "real")
+	if err := os.MkdirAll(realRoot, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(realRoot, "go.mod"), []byte("module example.com/symlink\n\ngo 1.26\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	linkRoot := filepath.Join(t.TempDir(), "link")
+	if err := os.Symlink(realRoot, linkRoot); err != nil {
+		t.Skipf("create root symlink: %v", err)
+	}
+	canonicalRoot, err := filepath.EvalSymlinks(realRoot)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv("GOENV", "off")
+	t.Setenv("GOWORK", "off")
+	t.Setenv("GOTOOLCHAIN", "local")
+	t.Setenv("PWD", filepath.Dir(linkRoot))
+	outside, err := Resolve(context.Background(), linkRoot)
+	if err != nil {
+		t.Fatalf("Resolve from outside symlink: %v", err)
+	}
+	t.Setenv("PWD", linkRoot)
+	inside, err := Resolve(context.Background(), linkRoot)
+	if err != nil {
+		t.Fatalf("Resolve from inside symlink: %v", err)
+	}
+
+	if outside.Fingerprint() != inside.Fingerprint() {
+		t.Fatalf("ambient PWD changed the fingerprint: outside=%s inside=%s", outside.Fingerprint(), inside.Fingerprint())
+	}
+	for name, config := range map[string]Config{"outside": outside, "inside": inside} {
+		if config.ModuleRoot() != canonicalRoot {
+			t.Fatalf("%s module root = %q, want canonical %q", name, config.ModuleRoot(), canonicalRoot)
+		}
+		if got := lastEnvironmentValue(config.Environment(), "PWD"); got != canonicalRoot {
+			t.Fatalf("%s PWD = %q, want canonical %q", name, got, canonicalRoot)
+		}
+	}
+}
+
+func TestResolveKeepsSymlinkedGoModAtItsContainingModuleRoot(t *testing.T) {
+	base := t.TempDir()
+	repository := filepath.Join(base, "repository")
+	shared := filepath.Join(base, "shared")
+	if err := os.MkdirAll(repository, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(shared, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	sharedMod := filepath.Join(shared, "base.mod")
+	if err := os.WriteFile(sharedMod, []byte("module example.com/modlink\n\ngo 1.26\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(sharedMod, filepath.Join(repository, "go.mod")); err != nil {
+		t.Skipf("create go.mod symlink: %v", err)
+	}
+
+	t.Setenv("GOENV", "off")
+	t.Setenv("GOWORK", "off")
+	t.Setenv("GOTOOLCHAIN", "local")
+	config, err := Resolve(context.Background(), repository)
+	if err != nil {
+		t.Fatalf("Resolve with symlinked go.mod: %v", err)
+	}
+	canonicalRepository, err := filepath.EvalSymlinks(repository)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if config.ModuleRoot() != canonicalRepository {
+		t.Fatalf("module root = %q, want containing repository %q", config.ModuleRoot(), canonicalRepository)
+	}
+	if config.ModulePath() != "example.com/modlink" {
+		t.Fatalf("module path = %q, want example.com/modlink", config.ModulePath())
 	}
 }
 
@@ -67,6 +162,102 @@ func TestConfigAccessorsReturnDefensiveCopies(t *testing.T) {
 	}
 }
 
+func TestResolveIgnoresSuccessfulStderr(t *testing.T) {
+	config, err := resolve(context.Background(), t.TempDir(), []string{"PATH=test"}, func(_ context.Context, _ string, _ []string, args ...string) ([]byte, []byte, error) {
+		if args[0] == "env" {
+			return []byte(testWireModuleContextJSON), []byte("go: module diagnostic\n"), nil
+		}
+		return []byte(testWireContextJSON), []byte("go: downloading go1.27.0\n"), nil
+	})
+	if err != nil {
+		t.Fatalf("resolve with successful stderr: %v", err)
+	}
+	if got := config.BuildContext(); got.GOOS != "linux" || got.GOARCH != "amd64" {
+		t.Fatalf("resolved context = %s/%s, want linux/amd64", got.GOOS, got.GOARCH)
+	}
+}
+
+func TestResolveReportsCommandDiagnostics(t *testing.T) {
+	commandErr := errors.New("exit status 1")
+	tests := []struct {
+		name   string
+		stdout string
+		stderr string
+		want   string
+	}{
+		{name: "stderr preferred", stdout: "stdout detail", stderr: "stderr detail", want: "stderr detail"},
+		{name: "stdout fallback", stdout: "stdout detail", want: "stdout detail"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := resolve(context.Background(), t.TempDir(), nil, func(context.Context, string, []string, ...string) ([]byte, []byte, error) {
+				return []byte(tc.stdout), []byte(tc.stderr), commandErr
+			})
+			if err == nil || !strings.Contains(err.Error(), tc.want) || !errors.Is(err, commandErr) {
+				t.Fatalf("resolve error = %v, want wrapped error containing %q", err, tc.want)
+			}
+		})
+	}
+}
+
+func TestResolveReportsModuleContextDiagnostics(t *testing.T) {
+	commandErr := errors.New("exit status 1")
+	_, err := resolve(context.Background(), t.TempDir(), nil, func(_ context.Context, _ string, _ []string, args ...string) ([]byte, []byte, error) {
+		if args[0] == "list" {
+			return []byte(testWireContextJSON), nil, nil
+		}
+		return nil, []byte("module diagnostic"), commandErr
+	})
+	if err == nil || !strings.Contains(err.Error(), "resolve Go module context") || !strings.Contains(err.Error(), "module diagnostic") || !errors.Is(err, commandErr) {
+		t.Fatalf("resolve error = %v, want wrapped module-context diagnostic", err)
+	}
+}
+
+func TestFingerprintTracksSelectionInputsAsSets(t *testing.T) {
+	first := build.Default
+	first.GOOS = "linux"
+	first.GOARCH = "amd64"
+	first.CgoEnabled = false
+	first.Compiler = "gc"
+	first.BuildTags = []string{"beta", "alpha"}
+	first.ToolTags = []string{"amd64.v2", "amd64.v1"}
+	first.ReleaseTags = []string{"go1.26", "go1.25"}
+
+	second := first
+	second.BuildTags = []string{"alpha", "beta"}
+	second.ToolTags = []string{"amd64.v1", "amd64.v2"}
+	second.ReleaseTags = []string{"go1.25", "go1.26"}
+	if got, want := FromBuildContext(first, nil).Fingerprint(), FromBuildContext(second, nil).Fingerprint(); got != want {
+		t.Fatalf("equivalent tag sets produced different fingerprints: %s != %s", got, want)
+	}
+
+	second.GOARCH = "arm64"
+	if got, notWant := FromBuildContext(second, nil).Fingerprint(), FromBuildContext(first, nil).Fingerprint(); got == notWant {
+		t.Fatalf("different GOARCH produced the same fingerprint: %s", got)
+	}
+
+	moduleRoot := t.TempDir()
+	moduleConfig := FromBuildContextWithModule(first, nil, true, moduleRoot)
+	if moduleConfig.Fingerprint() == FromBuildContext(first, nil).Fingerprint() {
+		t.Fatal("module-mode state did not affect the fingerprint")
+	}
+	otherRootConfig := FromBuildContextWithModule(first, nil, true, filepath.Join(moduleRoot, "other"))
+	if moduleConfig.Fingerprint() == otherRootConfig.Fingerprint() {
+		t.Fatal("module root did not affect the fingerprint")
+	}
+
+	differentGoRoot := first
+	differentGoRoot.GOROOT = filepath.Join(first.GOROOT, "other")
+	if FromBuildContext(first, nil).Fingerprint() == FromBuildContext(differentGoRoot, nil).Fingerprint() {
+		t.Fatal("GOROOT did not affect the fingerprint")
+	}
+	differentGoPath := first
+	differentGoPath.GOPATH = filepath.Join(first.GOPATH, "other")
+	if FromBuildContext(first, nil).Fingerprint() == FromBuildContext(differentGoPath, nil).Fingerprint() {
+		t.Fatal("GOPATH did not affect the fingerprint")
+	}
+}
+
 func buildContextFixture() build.Context {
 	ctx := build.Default
 	ctx.BuildTags = []string{"original"}
@@ -82,3 +273,7 @@ func lastEnvironmentValue(environment []string, key string) string {
 	}
 	return ""
 }
+
+const testWireContextJSON = `{"goos":"linux","goarch":"amd64","cgo_enabled":false,"use_all_files":false,"compiler":"gc","goroot":"/go","gopath":"/gopath","build_tags":["issue30"],"tool_tags":["amd64.v1"],"release_tags":["go1.26"],"install_suffix":""}`
+
+const testWireModuleContextJSON = `{"GO111MODULE":"","GOMOD":""}`

--- a/internal/cli/build_context_integration_test.go
+++ b/internal/cli/build_context_integration_test.go
@@ -1,0 +1,214 @@
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"reflect"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+
+	mcpprotocol "github.com/mark3labs/mcp-go/mcp"
+	"github.com/ozgurcd/gograph/internal/graph"
+	"github.com/ozgurcd/gograph/internal/search"
+)
+
+func TestIssue30IgnoredToolDoesNotPollutePreciseGraphOrMCP(t *testing.T) {
+	setDeterministicBuildEnvironment(t, "")
+	root := t.TempDir()
+	writeBuildContextFixture(t, root, "go.mod", "module example.com/issue30\n\ngo 1.26\n")
+	writeBuildContextFixture(t, root, "library.go", "package issue30\n\nfunc Active() {}\n")
+	toolPath := writeBuildContextFixture(t, root, "tool.go", `//go:build ignore
+
+package main
+
+func main() { panic("Issue30IgnoredToolSentinel") }
+`)
+
+	g, err := buildPreciseGraph(root)
+	if err != nil {
+		skipCoverageCacheFallback(t, g)
+		t.Fatalf("buildPreciseGraph: %v", err)
+	}
+	if got := g.Build.EffectivePrecision(); got != graph.PrecisionPrecise {
+		t.Fatalf("precision = %s, want %s", got, graph.PrecisionPrecise)
+	}
+	if g.Build.ScannedFiles != 1 || g.Build.ParsedFiles != 1 || len(g.Files) != 1 || g.Files[0].Path != "library.go" {
+		t.Fatalf("ignored tool affected file inventory: build=%+v files=%+v", g.Build, g.Files)
+	}
+
+	encoded, err := json.Marshal(g)
+	if err != nil {
+		t.Fatal(err)
+	}
+	graphOutput := string(encoded)
+	for _, inactiveValue := range []string{"tool.go", "Issue30IgnoredToolSentinel"} {
+		if strings.Contains(graphOutput, inactiveValue) {
+			t.Fatalf("inactive value %q leaked into graph output", inactiveValue)
+		}
+	}
+	if results := search.Query(g, []string{"main"}); len(results) != 0 {
+		t.Fatalf("query for main returned ignored-tool data: %+v", results)
+	}
+
+	newer := g.GeneratedAt.Add(time.Minute)
+	if err := os.Chtimes(toolPath, newer, newer); err != nil {
+		t.Fatal(err)
+	}
+	if stale := search.Stale(g, root); stale.IsStale {
+		t.Fatalf("ignored tool made graph stale: %+v", stale)
+	}
+
+	builds := 0
+	refresh := graphRefresher(
+		g,
+		root,
+		func(string) (*graph.Graph, error) { builds++; return nil, nil },
+		func(string) (*graph.Graph, error) { builds++; return nil, nil },
+	)
+	handlers := exposeMCPRefreshHandlers(t, g, refresh)
+	requests := []struct {
+		name      string
+		arguments map[string]any
+	}{
+		{name: "gograph_plan", arguments: map[string]any{"symbol": "Active"}},
+		{name: "gograph_review", arguments: map[string]any{"symbol": "Active"}},
+		{name: "gograph_check", arguments: map[string]any{}},
+	}
+	for _, requestCase := range requests {
+		handler := handlers[requestCase.name]
+		if handler == nil {
+			t.Fatalf("%s handler was not registered", requestCase.name)
+		}
+		request := mcpprotocol.CallToolRequest{}
+		request.Params.Arguments = requestCase.arguments
+		result, err := handler(context.Background(), request)
+		if err != nil {
+			t.Fatalf("%s handler: %v", requestCase.name, err)
+		}
+		if result == nil || result.IsError {
+			t.Fatalf("%s returned an MCP error: %s", requestCase.name, mcpResultText(t, result))
+		}
+	}
+	if builds != 0 {
+		t.Fatalf("ignored tool triggered %d MCP graph rebuild(s)", builds)
+	}
+}
+
+func TestBuildContextMatchesPrecisePackageLoading(t *testing.T) {
+	setDeterministicBuildEnvironment(t, "issue30_active")
+	root := t.TempDir()
+	writeBuildContextFixture(t, root, "go.mod", "module example.com/contextmatrix\n\ngo 1.26\n")
+	fixtures := map[string]string{
+		"active.go":           "package contextmatrix\n",
+		"platform_linux.go":   "package contextmatrix\n",
+		"platform_windows.go": "package contextmatrix\n",
+		"tag_active.go":       "//go:build issue30_active\n\npackage contextmatrix\n",
+		"tag_inactive.go":     "//go:build issue30_inactive\n\npackage contextmatrix\n",
+		"legacy_active.go":    "// +build issue30_active\n\npackage contextmatrix\n",
+		"legacy_inactive.go":  "// +build issue30_inactive\n\npackage contextmatrix\n",
+		"cgo.go":              "package contextmatrix\nimport \"C\"\n",
+		"active_test.go":      "//go:build issue30_active\n\npackage contextmatrix\nfunc TestActive() {}\n",
+		"inactive_test.go":    "//go:build issue30_inactive\n\npackage contextmatrix\nfunc TestInactive() {}\n",
+		"release_tool_tag.go": "//go:build go1.1 && amd64.v1\n\npackage contextmatrix\n",
+	}
+	for name, content := range fixtures {
+		writeBuildContextFixture(t, root, name, content)
+	}
+
+	g, err := buildPreciseGraph(root)
+	if err != nil {
+		skipCoverageCacheFallback(t, g)
+		t.Fatalf("buildPreciseGraph: %v", err)
+	}
+	if got := g.Build.EffectivePrecision(); got != graph.PrecisionPrecise {
+		t.Fatalf("precision = %s, want precise", got)
+	}
+	got := make([]string, 0, len(g.Files))
+	for _, file := range g.Files {
+		got = append(got, filepath.Base(file.Path))
+	}
+	sort.Strings(got)
+	want := []string{
+		"active.go",
+		"active_test.go",
+		"legacy_active.go",
+		"platform_linux.go",
+		"release_tool_tag.go",
+		"tag_active.go",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("precise graph files = %v, want %v", got, want)
+	}
+}
+
+func TestExplicitIgnoreTagMatchesGoToolchain(t *testing.T) {
+	setDeterministicBuildEnvironment(t, "ignore")
+	root := t.TempDir()
+	writeBuildContextFixture(t, root, "go.mod", "module example.com/explicitignore\n\ngo 1.26\n")
+	writeBuildContextFixture(t, root, "library.go", "package explicitignore\nfunc Library() {}\n")
+	writeBuildContextFixture(t, root, "tool.go", "//go:build ignore\n\npackage main\nfunc main() {}\n")
+
+	g, err := buildPreciseGraph(root)
+	if err == nil {
+		t.Fatal("explicit ignore tag unexpectedly accepted conflicting active packages")
+	}
+	skipCoverageCacheFallback(t, g)
+	if g == nil || g.Build.EffectivePrecision() != graph.PrecisionFallback || g.Build.ScannedFiles != 2 {
+		t.Fatalf("explicit ignore tag did not activate both files and fall back: graph=%+v", g)
+	}
+	if !strings.Contains(err.Error(), "found packages") {
+		t.Fatalf("explicit ignore tag returned an unexpected Go-tool error: %v", err)
+	}
+}
+
+func TestBuildPreciseGraphKeepsFallbackForNestedModuleCoverageGap(t *testing.T) {
+	setDeterministicBuildEnvironment(t, "")
+	root := t.TempDir()
+	writeBuildContextFixture(t, root, "go.mod", "module example.com/parent\n\ngo 1.26\n")
+	writeBuildContextFixture(t, root, "parent.go", "package parent\nfunc Parent() {}\n")
+	writeBuildContextFixture(t, root, "nested/go.mod", "module example.com/child\n\ngo 1.26\n")
+	writeBuildContextFixture(t, root, "nested/child.go", "package child\nfunc Child() {}\n")
+
+	g, err := buildPreciseGraph(root)
+	if err == nil {
+		t.Fatal("buildPreciseGraph unexpectedly accepted a nested-module coverage gap")
+	}
+	skipCoverageCacheFallback(t, g)
+	if g == nil || g.Build.EffectivePrecision() != graph.PrecisionFallback {
+		t.Fatalf("nested-module graph did not record precise_fallback: graph=%+v", g)
+	}
+	if !strings.Contains(err.Error(), "omitted 1 indexed production file") || !strings.Contains(err.Error(), filepath.Join("nested", "child.go")) {
+		t.Fatalf("unexpected coverage error: %v", err)
+	}
+}
+
+func setDeterministicBuildEnvironment(t *testing.T, tag string) {
+	t.Helper()
+	t.Setenv("GOENV", "off")
+	t.Setenv("GOWORK", "off")
+	t.Setenv("GOTOOLCHAIN", "local")
+	t.Setenv("GOOS", "linux")
+	t.Setenv("GOARCH", "amd64")
+	t.Setenv("CGO_ENABLED", "0")
+	if tag == "" {
+		t.Setenv("GOFLAGS", "")
+	} else {
+		t.Setenv("GOFLAGS", "-tags="+tag)
+	}
+}
+
+func writeBuildContextFixture(t *testing.T, root, name, content string) string {
+	t.Helper()
+	path := filepath.Join(root, name)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}

--- a/internal/cli/build_context_integration_test.go
+++ b/internal/cli/build_context_integration_test.go
@@ -28,19 +28,28 @@ package main
 func main() { panic("Issue30IgnoredToolSentinel") }
 `)
 
-	g, err := buildPreciseGraph(root)
+	if code := runBuild([]string{root, "--precise"}); code != 0 {
+		t.Fatalf("runBuild --precise exit code = %d, want 0", code)
+	}
+	data, err := os.ReadFile(filepath.Join(root, graphFile))
 	if err != nil {
-		skipCoverageCacheFallback(t, g)
-		t.Fatalf("buildPreciseGraph: %v", err)
+		t.Fatalf("read persisted precise graph: %v", err)
+	}
+	var g graph.Graph
+	if err := json.Unmarshal(data, &g); err != nil {
+		t.Fatalf("decode persisted precise graph: %v", err)
 	}
 	if got := g.Build.EffectivePrecision(); got != graph.PrecisionPrecise {
 		t.Fatalf("precision = %s, want %s", got, graph.PrecisionPrecise)
+	}
+	if g.Build.BuildContextFingerprint == "" {
+		t.Fatal("precise graph did not record a build-context fingerprint")
 	}
 	if g.Build.ScannedFiles != 1 || g.Build.ParsedFiles != 1 || len(g.Files) != 1 || g.Files[0].Path != "library.go" {
 		t.Fatalf("ignored tool affected file inventory: build=%+v files=%+v", g.Build, g.Files)
 	}
 
-	encoded, err := json.Marshal(g)
+	encoded, err := json.Marshal(&g)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -50,7 +59,7 @@ func main() { panic("Issue30IgnoredToolSentinel") }
 			t.Fatalf("inactive value %q leaked into graph output", inactiveValue)
 		}
 	}
-	if results := search.Query(g, []string{"main"}); len(results) != 0 {
+	if results := search.Query(&g, []string{"main"}); len(results) != 0 {
 		t.Fatalf("query for main returned ignored-tool data: %+v", results)
 	}
 
@@ -58,18 +67,18 @@ func main() { panic("Issue30IgnoredToolSentinel") }
 	if err := os.Chtimes(toolPath, newer, newer); err != nil {
 		t.Fatal(err)
 	}
-	if stale := search.Stale(g, root); stale.IsStale {
+	if stale := search.Stale(&g, root); stale.IsStale {
 		t.Fatalf("ignored tool made graph stale: %+v", stale)
 	}
 
 	builds := 0
 	refresh := graphRefresher(
-		g,
+		&g,
 		root,
 		func(string) (*graph.Graph, error) { builds++; return nil, nil },
 		func(string) (*graph.Graph, error) { builds++; return nil, nil },
 	)
-	handlers := exposeMCPRefreshHandlers(t, g, refresh)
+	handlers := exposeMCPRefreshHandlers(t, &g, refresh)
 	requests := []struct {
 		name      string
 		arguments map[string]any
@@ -103,17 +112,22 @@ func TestBuildContextMatchesPrecisePackageLoading(t *testing.T) {
 	root := t.TempDir()
 	writeBuildContextFixture(t, root, "go.mod", "module example.com/contextmatrix\n\ngo 1.26\n")
 	fixtures := map[string]string{
-		"active.go":           "package contextmatrix\n",
-		"platform_linux.go":   "package contextmatrix\n",
-		"platform_windows.go": "package contextmatrix\n",
-		"tag_active.go":       "//go:build issue30_active\n\npackage contextmatrix\n",
-		"tag_inactive.go":     "//go:build issue30_inactive\n\npackage contextmatrix\n",
-		"legacy_active.go":    "// +build issue30_active\n\npackage contextmatrix\n",
-		"legacy_inactive.go":  "// +build issue30_inactive\n\npackage contextmatrix\n",
-		"cgo.go":              "package contextmatrix\nimport \"C\"\n",
-		"active_test.go":      "//go:build issue30_active\n\npackage contextmatrix\nfunc TestActive() {}\n",
-		"inactive_test.go":    "//go:build issue30_inactive\n\npackage contextmatrix\nfunc TestInactive() {}\n",
-		"release_tool_tag.go": "//go:build go1.1 && amd64.v1\n\npackage contextmatrix\n",
+		"active.go":                     "package contextmatrix\n",
+		"platform_amd64.go":             "package contextmatrix\n",
+		"platform_arm64.go":             "package contextmatrix\n",
+		"platform_linux.go":             "package contextmatrix\n",
+		"platform_windows.go":           "package contextmatrix\n",
+		"tag_active.go":                 "//go:build issue30_active\n\npackage contextmatrix\n",
+		"tag_inactive.go":               "//go:build issue30_inactive\n\npackage contextmatrix\n",
+		"legacy_active.go":              "// +build issue30_active\n\npackage contextmatrix\n",
+		"legacy_inactive.go":            "// +build issue30_inactive\n\npackage contextmatrix\n",
+		"cgo.go":                        "package contextmatrix\nimport \"C\"\n",
+		"active_test.go":                "//go:build issue30_active\n\npackage contextmatrix\nfunc TestActive() {}\n",
+		"inactive_test.go":              "//go:build issue30_inactive\n\npackage contextmatrix\nfunc TestInactive() {}\n",
+		"release_tool_tag.go":           "//go:build go1.1 && amd64.v1\n\npackage contextmatrix\n",
+		".scratch/hidden_dot.go":        "package scratch\nfunc HiddenDotSentinel() {}\n",
+		"_scratch/hidden_underscore.go": "package scratch\nfunc HiddenUnderscoreSentinel() {}\n",
+		"testdata/hidden_testdata.go":   "package testdata\nfunc HiddenTestdataSentinel() {}\n",
 	}
 	for name, content := range fixtures {
 		writeBuildContextFixture(t, root, name, content)
@@ -136,12 +150,317 @@ func TestBuildContextMatchesPrecisePackageLoading(t *testing.T) {
 		"active.go",
 		"active_test.go",
 		"legacy_active.go",
+		"platform_amd64.go",
 		"platform_linux.go",
 		"release_tool_tag.go",
 		"tag_active.go",
 	}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("precise graph files = %v, want %v", got, want)
+	}
+	encoded, err := json.Marshal(g)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, inactive := range []string{"HiddenDotSentinel", "HiddenUnderscoreSentinel", "HiddenTestdataSentinel", "TestInactive"} {
+		if strings.Contains(string(encoded), inactive) {
+			t.Fatalf("inactive symbol %q leaked into precise graph", inactive)
+		}
+	}
+	if !strings.Contains(string(encoded), "TestActive") {
+		t.Fatal("active constrained test symbol was not indexed")
+	}
+}
+
+func TestGoModIgnoreMatchesPrecisePackageLoading(t *testing.T) {
+	setDeterministicBuildEnvironment(t, "")
+	root := t.TempDir()
+	writeBuildContextFixture(t, root, "go.mod", `module example.com/modignore
+
+go 1.26
+
+ignore (
+	ignored
+	./anchored
+)
+`)
+	writeBuildContextFixture(t, root, "root.go", "package modignore\nfunc Root() {}\n")
+	writeBuildContextFixture(t, root, "ignored/noise.go", "package ignored\nfunc IgnoredSentinel() {}\n")
+	writeBuildContextFixture(t, root, "deep/ignored/noise.go", "package ignored\nfunc DeepIgnoredSentinel() {}\n")
+	writeBuildContextFixture(t, root, "anchored/noise.go", "package anchored\nfunc AnchoredIgnoredSentinel() {}\n")
+	writeBuildContextFixture(t, root, "deep/anchored/keep.go", "package anchored\nfunc DeepAnchoredKept() {}\n")
+	writeBuildContextFixture(t, root, "ignored2/keep.go", "package ignored2\nfunc SimilarNameKept() {}\n")
+
+	g, err := buildPreciseGraph(root)
+	if err != nil {
+		skipCoverageCacheFallback(t, g)
+		t.Fatalf("buildPreciseGraph: %v", err)
+	}
+	if got := g.Build.EffectivePrecision(); got != graph.PrecisionPrecise {
+		t.Fatalf("precision = %s, want precise", got)
+	}
+	encoded, err := json.Marshal(g)
+	if err != nil {
+		t.Fatal(err)
+	}
+	text := string(encoded)
+	for _, excluded := range []string{"IgnoredSentinel", "DeepIgnoredSentinel", "AnchoredIgnoredSentinel"} {
+		if strings.Contains(text, excluded) {
+			t.Fatalf("go.mod-ignored symbol %q leaked into graph", excluded)
+		}
+	}
+	for _, included := range []string{"Root", "DeepAnchoredKept", "SimilarNameKept"} {
+		if !strings.Contains(text, included) {
+			t.Fatalf("eligible symbol %q was omitted from graph", included)
+		}
+	}
+}
+
+func TestGoModIgnoreMatchesPreciseLoadingFromModuleSubdirectory(t *testing.T) {
+	setDeterministicBuildEnvironment(t, "")
+	moduleRoot := t.TempDir()
+	writeBuildContextFixture(t, moduleRoot, "go.mod", "module example.com/subdirignore\n\ngo 1.26\n\nignore ignored\n")
+	scanRoot := filepath.Join(moduleRoot, "pkg")
+	writeBuildContextFixture(t, scanRoot, "keep.go", "package pkg\nfunc Keep() {}\n")
+	writeBuildContextFixture(t, scanRoot, "ignored/noise.go", "package ignored\nfunc ParentIgnoredSentinel() {}\n")
+
+	g, err := buildPreciseGraph(scanRoot)
+	if err != nil {
+		skipCoverageCacheFallback(t, g)
+		t.Fatalf("buildPreciseGraph from module subdirectory: %v", err)
+	}
+	if got := g.Build.EffectivePrecision(); got != graph.PrecisionPrecise {
+		t.Fatalf("precision = %s, want precise", got)
+	}
+	encoded, err := json.Marshal(g)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(encoded), "ParentIgnoredSentinel") {
+		t.Fatal("parent-module ignored symbol leaked into subdirectory graph")
+	}
+	if !strings.Contains(string(encoded), "Keep") {
+		t.Fatal("eligible subdirectory symbol was omitted")
+	}
+	if len(g.Symbols) != 1 || g.Symbols[0].ID != "example.com/subdirignore/pkg::Keep" {
+		t.Fatalf("subdirectory symbol identity = %+v, want module-qualified Keep", g.Symbols)
+	}
+}
+
+func TestPreciseBuildFollowsExplicitRootSymlink(t *testing.T) {
+	setDeterministicBuildEnvironment(t, "")
+	realRoot := filepath.Join(t.TempDir(), "real")
+	writeBuildContextFixture(t, realRoot, "go.mod", "module example.com/rootlink\n\ngo 1.26\n")
+	writeBuildContextFixture(t, realRoot, "root.go", "package rootlink\nfunc RootLink() {}\n")
+	linkRoot := filepath.Join(t.TempDir(), "linked-root")
+	if err := os.Symlink(realRoot, linkRoot); err != nil {
+		t.Skipf("create root symlink: %v", err)
+	}
+	t.Setenv("PWD", filepath.Dir(linkRoot))
+
+	g, err := buildPreciseGraph(linkRoot)
+	if err != nil {
+		skipCoverageCacheFallback(t, g)
+		t.Fatalf("buildPreciseGraph through root symlink: %v", err)
+	}
+	if got := g.Build.EffectivePrecision(); got != graph.PrecisionPrecise || len(g.Files) != 1 || g.Files[0].Path != "root.go" {
+		t.Fatalf("root-symlink precise graph = precision:%s files:%+v", got, g.Files)
+	}
+	if len(g.Symbols) != 1 || g.Symbols[0].ID != "example.com/rootlink::RootLink" {
+		t.Fatalf("root-symlink symbol identity = %+v", g.Symbols)
+	}
+	t.Setenv("PWD", linkRoot)
+	if stale := search.Stale(g, linkRoot); stale.IsStale {
+		t.Fatalf("new graph built outside and queried inside root symlink was immediately stale: %+v", stale)
+	}
+}
+
+func TestPreciseBuildAlignsSymlinkedModuleSubdirectoryIdentity(t *testing.T) {
+	setDeterministicBuildEnvironment(t, "")
+	moduleRoot := filepath.Join(t.TempDir(), "module")
+	writeBuildContextFixture(t, moduleRoot, "go.mod", "module example.com/root\n\ngo 1.26\n\nignore ./pkg/ignored\n")
+	packageRoot := filepath.Join(moduleRoot, "pkg")
+	writeBuildContextFixture(t, packageRoot, "runner.go", `package pkg
+
+type Runner interface { Run() }
+type Impl struct{}
+func (*Impl) Run() {}
+func Invoke(r Runner) { r.Run() }
+`)
+	writeBuildContextFixture(t, packageRoot, "ignored/noise.go", "package ignored\nfunc SymlinkIgnoredSentinel() {}\n")
+	linkRoot := filepath.Join(t.TempDir(), "linked-pkg")
+	if err := os.Symlink(packageRoot, linkRoot); err != nil {
+		t.Skipf("create package symlink: %v", err)
+	}
+	t.Setenv("PWD", filepath.Dir(linkRoot))
+
+	g, err := buildPreciseGraph(linkRoot)
+	if err != nil {
+		skipCoverageCacheFallback(t, g)
+		t.Fatalf("buildPreciseGraph through package symlink: %v", err)
+	}
+	if got := g.Build.EffectivePrecision(); got != graph.PrecisionPrecise {
+		t.Fatalf("package-symlink precision = %s, want precise", got)
+	}
+	if len(g.Files) != 1 || g.Files[0].Path != "runner.go" {
+		t.Fatalf("package-symlink selected files = %+v, want runner.go only", g.Files)
+	}
+	symbolIDs := make(map[string]struct{}, len(g.Symbols))
+	for _, symbol := range g.Symbols {
+		symbolIDs[symbol.ID] = struct{}{}
+	}
+	for _, edge := range g.Implements {
+		if _, ok := symbolIDs[edge.InterfaceID]; !ok {
+			t.Fatalf("package-symlink interface ID %q has no AST symbol", edge.InterfaceID)
+		}
+		if _, ok := symbolIDs[edge.ConcreteID]; !ok {
+			t.Fatalf("package-symlink concrete ID %q has no AST symbol", edge.ConcreteID)
+		}
+	}
+	for _, call := range g.Calls {
+		if call.CalleeSymbolID != "" {
+			if _, ok := symbolIDs[call.CalleeSymbolID]; !ok {
+				t.Fatalf("package-symlink callee ID %q has no AST symbol", call.CalleeSymbolID)
+			}
+		}
+	}
+	if len(g.Implements) == 0 {
+		t.Fatal("package-symlink fixture produced no precise implements edge")
+	}
+	t.Setenv("PWD", linkRoot)
+	if stale := search.Stale(g, linkRoot); stale.IsStale {
+		t.Fatalf("new graph built outside and queried inside package symlink was immediately stale: %+v", stale)
+	}
+}
+
+func TestPreciseBuildKeepsSymlinkedGoModIdentityAligned(t *testing.T) {
+	setDeterministicBuildEnvironment(t, "")
+	base := t.TempDir()
+	repository := filepath.Join(base, "repository")
+	sharedMod := writeBuildContextFixture(t, filepath.Join(base, "shared"), "base.mod", "module example.com/modlink\n\ngo 1.26\n")
+	if err := os.MkdirAll(repository, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(sharedMod, filepath.Join(repository, "go.mod")); err != nil {
+		t.Skipf("create go.mod symlink: %v", err)
+	}
+	writeBuildContextFixture(t, repository, "service.go", `package modlink
+
+type Service interface { Run() }
+type Implementation struct{}
+func (*Implementation) Run() {}
+func Invoke(service Service) { service.Run() }
+`)
+
+	g, err := buildPreciseGraph(repository)
+	if err != nil {
+		skipCoverageCacheFallback(t, g)
+		t.Fatalf("buildPreciseGraph with symlinked go.mod: %v", err)
+	}
+	if got := g.Build.EffectivePrecision(); got != graph.PrecisionPrecise {
+		t.Fatalf("symlinked-go.mod precision = %s, want precise", got)
+	}
+	symbolIDs := make(map[string]struct{}, len(g.Symbols))
+	for _, symbol := range g.Symbols {
+		symbolIDs[symbol.ID] = struct{}{}
+		if !strings.HasPrefix(symbol.ID, "example.com/modlink::") {
+			t.Fatalf("symbol ID %q does not use module identity", symbol.ID)
+		}
+	}
+	if len(g.Implements) == 0 {
+		t.Fatal("symlinked-go.mod fixture produced no precise implements edge")
+	}
+	for _, edge := range g.Implements {
+		if _, ok := symbolIDs[edge.InterfaceID]; !ok {
+			t.Fatalf("interface ID %q has no AST symbol", edge.InterfaceID)
+		}
+		if _, ok := symbolIDs[edge.ConcreteID]; !ok {
+			t.Fatalf("concrete ID %q has no AST symbol", edge.ConcreteID)
+		}
+	}
+}
+
+func TestModuleIgnoreAtExplicitRootMatchesPackageLoading(t *testing.T) {
+	setDeterministicBuildEnvironment(t, "")
+	moduleRoot := t.TempDir()
+	writeBuildContextFixture(t, moduleRoot, "go.mod", "module example.com/ignoredroot\n\ngo 1.26\n\nignore ./ignored\n")
+	scanRoot := filepath.Join(moduleRoot, "ignored")
+	writeBuildContextFixture(t, scanRoot, "noise.go", "package ignored\nfunc IgnoredRootSentinel() {}\n")
+
+	g, err := buildPreciseGraph(scanRoot)
+	if err == nil || g != nil || !strings.Contains(err.Error(), "no Go files") {
+		t.Fatalf("ignored explicit root graph=%+v err=%v, want no-file rejection", g, err)
+	}
+}
+
+func TestNestedModuleBoundaryChangesMakeGraphStale(t *testing.T) {
+	setDeterministicBuildEnvironment(t, "")
+	root := t.TempDir()
+	writeBuildContextFixture(t, root, "go.mod", "module example.com/boundary\n\ngo 1.26\n")
+	writeBuildContextFixture(t, root, "parent.go", "package boundary\nfunc Parent() {}\n")
+	writeBuildContextFixture(t, root, "nested/child.go", "package nested\nfunc Child() {}\n")
+
+	preciseGraph, err := buildPreciseGraph(root)
+	if err != nil {
+		skipCoverageCacheFallback(t, preciseGraph)
+		t.Fatalf("initial precise graph: %v", err)
+	}
+	boundaryPath := writeBuildContextFixture(t, root, "nested/go.mod", "module example.com/nested\n\ngo 1.26\n")
+	if stale := search.Stale(preciseGraph, root); !stale.IsStale || !stale.BuildContextChanged || len(stale.ChangedFiles) != 0 {
+		t.Fatalf("added nested module boundary was not a context-only freshness change: %+v", stale)
+	}
+
+	fallbackGraph, err := buildPreciseGraph(root)
+	if err == nil || fallbackGraph == nil || fallbackGraph.Build.EffectivePrecision() != graph.PrecisionFallback {
+		t.Fatalf("nested module boundary did not preserve genuine fallback: graph=%+v err=%v", fallbackGraph, err)
+	}
+	if err := os.Remove(boundaryPath); err != nil {
+		t.Fatal(err)
+	}
+	if stale := search.Stale(fallbackGraph, root); !stale.IsStale || !stale.BuildContextChanged || len(stale.ChangedFiles) != 0 {
+		t.Fatalf("removed nested module boundary was not a context-only freshness change: %+v", stale)
+	}
+}
+
+func TestGO111MODULEOffKeepsScannerAndPreciseIdentityAligned(t *testing.T) {
+	setDeterministicBuildEnvironment(t, "")
+	t.Setenv("GO111MODULE", "off")
+	root := t.TempDir()
+	writeBuildContextFixture(t, root, "go.mod", "module example.com/wrong-if-used\n\ngo 1.26\n\nignore ignored\n")
+	writeBuildContextFixture(t, root, "root.go", `package offids
+
+type Runner interface { Run() }
+type Impl struct{}
+func (Impl) Run() {}
+func Invoke(r Runner) { r.Run() }
+`)
+	writeBuildContextFixture(t, root, "ignored/noise.go", "package ignored\nfunc IncludedWithModulesOff() {}\n")
+
+	g, err := buildPreciseGraph(root)
+	if err != nil {
+		skipCoverageCacheFallback(t, g)
+		t.Fatalf("GO111MODULE=off precise graph: %v", err)
+	}
+	if got := g.Build.EffectivePrecision(); got != graph.PrecisionPrecise || len(g.Files) != 2 {
+		t.Fatalf("module-off graph = precision:%s files:%+v", got, g.Files)
+	}
+	symbolIDs := make(map[string]struct{}, len(g.Symbols))
+	for _, symbol := range g.Symbols {
+		symbolIDs[symbol.ID] = struct{}{}
+		if strings.HasPrefix(symbol.ID, "example.com/wrong-if-used::") {
+			t.Fatalf("module-off symbol used go.mod identity: %s", symbol.ID)
+		}
+	}
+	for _, edge := range g.Implements {
+		if _, ok := symbolIDs[edge.InterfaceID]; !ok {
+			t.Fatalf("precise interface ID %q has no AST symbol", edge.InterfaceID)
+		}
+		if _, ok := symbolIDs[edge.ConcreteID]; !ok {
+			t.Fatalf("precise concrete ID %q has no AST symbol", edge.ConcreteID)
+		}
+	}
+	if len(g.Implements) == 0 {
+		t.Fatal("module-off fixture produced no precise implements edge")
 	}
 }
 
@@ -170,8 +489,9 @@ func TestBuildPreciseGraphKeepsFallbackForNestedModuleCoverageGap(t *testing.T) 
 	root := t.TempDir()
 	writeBuildContextFixture(t, root, "go.mod", "module example.com/parent\n\ngo 1.26\n")
 	writeBuildContextFixture(t, root, "parent.go", "package parent\nfunc Parent() {}\n")
-	writeBuildContextFixture(t, root, "nested/go.mod", "module example.com/child\n\ngo 1.26\n")
+	writeBuildContextFixture(t, root, "nested/go.mod", "module example.com/child\n\ngo 1.26\n\nignore ignored\n")
 	writeBuildContextFixture(t, root, "nested/child.go", "package child\nfunc Child() {}\n")
+	writeBuildContextFixture(t, root, "nested/ignored/noise.go", "package ignored\nfunc NestedIgnoredSentinel() {}\n")
 
 	g, err := buildPreciseGraph(root)
 	if err == nil {
@@ -184,6 +504,13 @@ func TestBuildPreciseGraphKeepsFallbackForNestedModuleCoverageGap(t *testing.T) 
 	if !strings.Contains(err.Error(), "omitted 1 indexed production file") || !strings.Contains(err.Error(), filepath.Join("nested", "child.go")) {
 		t.Fatalf("unexpected coverage error: %v", err)
 	}
+	encoded, marshalErr := json.Marshal(g)
+	if marshalErr != nil {
+		t.Fatal(marshalErr)
+	}
+	if strings.Contains(string(encoded), "NestedIgnoredSentinel") {
+		t.Fatal("nested module ignore directive leaked into fallback graph")
+	}
 }
 
 func setDeterministicBuildEnvironment(t *testing.T, tag string) {
@@ -191,6 +518,7 @@ func setDeterministicBuildEnvironment(t *testing.T, tag string) {
 	t.Setenv("GOENV", "off")
 	t.Setenv("GOWORK", "off")
 	t.Setenv("GOTOOLCHAIN", "local")
+	t.Setenv("GO111MODULE", "")
 	t.Setenv("GOOS", "linux")
 	t.Setenv("GOARCH", "amd64")
 	t.Setenv("CGO_ENABLED", "0")

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"go/build"
 	"go/token"
 	"os"
 	"os/exec"
@@ -16,6 +17,7 @@ import (
 	"time"
 
 	"github.com/ozgurcd/gograph/internal/baseline"
+	"github.com/ozgurcd/gograph/internal/buildctx"
 	"github.com/ozgurcd/gograph/internal/graph"
 	"github.com/ozgurcd/gograph/internal/mcp"
 	"github.com/ozgurcd/gograph/internal/parser"
@@ -608,7 +610,8 @@ func runBuild(args []string) int {
 		}
 	}
 
-	g, err := BuildGraph(absRoot)
+	buildConfig, configErr := resolveBuildConfig(absRoot)
+	g, err := buildGraphWithConfig(absRoot, buildConfig, configErr)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "error building graph: %v\n", err)
 		return 1
@@ -617,7 +620,7 @@ func runBuild(args []string) int {
 
 	if preciseMode {
 		fmt.Println("  running type-checked precision analysis (this may take a moment)...")
-		if err := enrichGraphPrecisely(absRoot, g); err != nil {
+		if err := enrichGraphPreciselyWithConfig(absRoot, g, buildConfig, configErr); err != nil {
 			fmt.Fprintf(os.Stderr, "warning: precise enrichment failed: %v\n", err)
 		}
 	}
@@ -668,7 +671,15 @@ func runBuild(args []string) int {
 }
 
 func BuildGraph(absRoot string) (*graph.Graph, error) {
-	files, walkErrs := scanner.Walk(absRoot)
+	buildConfig, configErr := resolveBuildConfig(absRoot)
+	return buildGraphWithConfig(absRoot, buildConfig, configErr)
+}
+
+func buildGraphWithConfig(absRoot string, buildConfig buildctx.Config, configErr error) (*graph.Graph, error) {
+	files, walkErrs := scanner.WalkWithContext(absRoot, buildConfig.BuildContext())
+	if configErr != nil {
+		walkErrs = append([]error{fmt.Errorf("using default Go build context: %w", configErr)}, walkErrs...)
+	}
 	buildMetadata := &graph.BuildMetadata{
 		ScannedFiles: len(files),
 		Precision:    graph.PrecisionAST,
@@ -774,15 +785,20 @@ func BuildGraph(absRoot string) (*graph.Graph, error) {
 	return g, nil
 }
 
-// enrichGraphPrecisely records the outcome in the graph even when enrichment
-// fails. Callers may continue using the AST graph, but the durable fallback
-// state makes that downgrade visible and preserves the request to retry precise
-// analysis after a future source edit.
-func enrichGraphPrecisely(absRoot string, g *graph.Graph) error {
+// enrichGraphPreciselyWithConfig records the outcome in the graph even when
+// enrichment fails. Callers may continue using the AST graph, but the durable
+// fallback state makes that downgrade visible and preserves the request to
+// retry precise analysis after a future source edit.
+func enrichGraphPreciselyWithConfig(absRoot string, g *graph.Graph, buildConfig buildctx.Config, configErr error) error {
 	if g.Build == nil {
 		g.Build = &graph.BuildMetadata{}
 	}
-	err := precise.Enrich(absRoot, g)
+	var err error
+	if configErr != nil {
+		err = fmt.Errorf("build context resolution failed: %w", configErr)
+	} else {
+		err = precise.EnrichWithConfig(absRoot, g, buildConfig)
+	}
 	if err != nil {
 		g.Build.Precision = graph.PrecisionFallback
 		g.Build.Warnings = append(g.Build.Warnings, "precise enrichment failed: "+err.Error())
@@ -797,16 +813,25 @@ func enrichGraphPrecisely(absRoot string, g *graph.Graph) error {
 // fallback graph for diagnostics but returns an error so MCP analysis cannot
 // silently serve AST-only results.
 func buildPreciseGraph(absRoot string) (*graph.Graph, error) {
-	g, err := BuildGraph(absRoot)
+	buildConfig, configErr := resolveBuildConfig(absRoot)
+	g, err := buildGraphWithConfig(absRoot, buildConfig, configErr)
 	if err != nil {
 		return nil, err
 	}
-	if err := enrichGraphPrecisely(absRoot, g); err != nil {
+	if err := enrichGraphPreciselyWithConfig(absRoot, g, buildConfig, configErr); err != nil {
 		fmt.Fprintf(os.Stderr, "warning: precise MCP refresh fell back to AST analysis: %v\n", err)
 		return g, fmt.Errorf("precise MCP refresh failed; graph is precise_fallback: %w", err)
 	}
 	sortGraph(g)
 	return g, nil
+}
+
+func resolveBuildConfig(absRoot string) (buildctx.Config, error) {
+	config, err := buildctx.Resolve(context.Background(), absRoot)
+	if err == nil {
+		return config, nil
+	}
+	return buildctx.FromBuildContext(build.Default, os.Environ()), err
 }
 
 func precisionFallbackError(g *graph.Graph) error {

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -10,11 +10,13 @@ import (
 	"go/token"
 	"os"
 	"os/exec"
+	pathpkg "path"
 	"path/filepath"
 	"sort"
 	"strconv"
 	"strings"
 	"time"
+	"unicode"
 
 	"github.com/ozgurcd/gograph/internal/baseline"
 	"github.com/ozgurcd/gograph/internal/buildctx"
@@ -341,7 +343,7 @@ when available; outside Git, the build target .gitignore is used.
 If no Go files are found, or none can be parsed, build exits before replacing artifacts.
 Partial builds record failed files in graph.json for machine-readable health checks.
   gograph stats   → counts plus complete/partial build and ast/precise/fallback status
-  gograph stale   → lists source files newer than graph.json (shows newest source time/file)
+  gograph stale   → checks source selection, build context, and modification times
 
 CLI queries use this persisted snapshot, so rebuild whenever source files change.
 The MCP server checks source freshness and newer persisted graphs per call. After
@@ -471,9 +473,9 @@ AGENT WORKFLOW RULES (CRITICAL):
 
 INDEXING:
 build . [--precise]  : parse AST, atomically write graph.json + reports to .gograph/
-                       Skips .git, vendor, testdata, .claude, .cursor, .agents, and
-                       any files or directories listed in .gitignore (via git check-ignore).
-stale                : list source files newer than graph.json (shows newest source time/file)
+                       Honors Go build constraints and cmd/go package-directory rules;
+                       skips generated, module-ignored, and Git-ignored sources.
+stale                : check source selection, build context, and modification times
 stats                : schema/build/precision health, parse failures, and symbol/call/route counts
 
 QUERY COMMANDS:
@@ -676,13 +678,14 @@ func BuildGraph(absRoot string) (*graph.Graph, error) {
 }
 
 func buildGraphWithConfig(absRoot string, buildConfig buildctx.Config, configErr error) (*graph.Graph, error) {
-	files, walkErrs := scanner.WalkWithContext(absRoot, buildConfig.BuildContext())
+	files, selectionFingerprint, walkErrs := scanner.WalkWithConfigAndFingerprint(absRoot, buildConfig)
 	if configErr != nil {
 		walkErrs = append([]error{fmt.Errorf("using default Go build context: %w", configErr)}, walkErrs...)
 	}
 	buildMetadata := &graph.BuildMetadata{
-		ScannedFiles: len(files),
-		Precision:    graph.PrecisionAST,
+		ScannedFiles:            len(files),
+		Precision:               graph.PrecisionAST,
+		BuildContextFingerprint: selectionFingerprint,
 	}
 	for _, e := range walkErrs {
 		fmt.Fprintf(os.Stderr, "  warning: %v\n", e)
@@ -715,7 +718,7 @@ func buildGraphWithConfig(absRoot string, buildConfig buildctx.Config, configErr
 		}
 		dir := filepath.Dir(rel)
 		if _, seen := dirToImportPath[dir]; !seen {
-			dirToImportPath[dir] = bestEffortImportPath(absRoot, dir)
+			dirToImportPath[dir] = bestEffortImportPath(absRoot, dir, buildConfig)
 		}
 	}
 
@@ -827,11 +830,7 @@ func buildPreciseGraph(absRoot string) (*graph.Graph, error) {
 }
 
 func resolveBuildConfig(absRoot string) (buildctx.Config, error) {
-	config, err := buildctx.Resolve(context.Background(), absRoot)
-	if err == nil {
-		return config, nil
-	}
-	return buildctx.FromBuildContext(build.Default, os.Environ()), err
+	return buildctx.ResolveOrDefault(context.Background(), absRoot)
 }
 
 func precisionFallbackError(g *graph.Graph) error {
@@ -1204,7 +1203,7 @@ func graphRefresher(
 				return latest, nil
 			}
 		}
-		return nil, fmt.Errorf("graph remained stale after %d refresh attempts (%d changed source files)", maxAttempts, len(stale.ChangedFiles))
+		return nil, fmt.Errorf("graph remained stale after %d refresh attempts (%d freshness changes)", maxAttempts, stale.ChangeCount())
 	}
 }
 
@@ -1458,23 +1457,58 @@ func parseDependencies(absRoot string) ([]graph.Dependency, error) {
 	return deps, nil
 }
 
-func bestEffortImportPath(absRoot, relDir string) string {
-	modPath := filepath.Join(absRoot, "go.mod")
-	data, err := os.ReadFile(modPath)
-	if err != nil {
-		return relDir
+func bestEffortImportPath(absRoot, relDir string, config buildctx.Config) string {
+	absDir := absRoot
+	if relDir != "." && relDir != "" {
+		absDir = filepath.Join(absRoot, relDir)
 	}
-	for _, line := range strings.Split(string(data), "\n") {
-		line = strings.TrimSpace(line)
-		if strings.HasPrefix(line, "module ") {
-			mod := strings.TrimSpace(strings.TrimPrefix(line, "module "))
-			if relDir == "." || relDir == "" {
-				return mod
+	if config.ModulesEnabled() && config.ModuleRoot() != "" {
+		modulePath := config.ModulePath()
+		moduleRoot := canonicalExistingPath(config.ModuleRoot())
+		packageDir := canonicalExistingPath(absDir)
+		if modulePath != "" {
+			if relative, relErr := filepath.Rel(moduleRoot, packageDir); relErr == nil && pathWithinRoot(relative) {
+				if relative == "." {
+					return modulePath
+				}
+				return pathpkg.Join(modulePath, filepath.ToSlash(relative))
 			}
-			return mod + "/" + filepath.ToSlash(relDir)
 		}
 	}
-	return relDir
+
+	buildContext := config.BuildContext()
+	if pkg, _ := buildContext.ImportDir(absDir, build.FindOnly); pkg != nil && pkg.ImportPath != "" && pkg.ImportPath != "." {
+		return pkg.ImportPath
+	}
+	return pseudoImportPath(absDir)
+}
+
+func canonicalExistingPath(path string) string {
+	if absolute, err := filepath.Abs(path); err == nil {
+		path = absolute
+	}
+	if resolved, err := filepath.EvalSymlinks(path); err == nil {
+		path = resolved
+	}
+	return filepath.Clean(path)
+}
+
+func pathWithinRoot(relative string) bool {
+	return relative != ".." && !strings.HasPrefix(relative, ".."+string(filepath.Separator))
+}
+
+func pseudoImportPath(dir string) string {
+	if absolute, err := filepath.Abs(dir); err == nil {
+		dir = absolute
+	}
+	valid := strings.Map(func(char rune) rune {
+		const illegal = `!"#$%&'()*,:;<=>?[\]^{|}` + "`\uFFFD"
+		if !unicode.IsGraphic(char) || unicode.IsSpace(char) || strings.ContainsRune(illegal, char) {
+			return '_'
+		}
+		return char
+	}, filepath.ToSlash(filepath.Clean(dir)))
+	return pathpkg.Join("_", valid)
 }
 
 func sortGraph(g *graph.Graph) {
@@ -1703,9 +1737,10 @@ INDEXING
                              Supports --precise to perform type-checked Class
                              Hierarchy/SSA enrichment. If enrichment fails, warns,
                              publishes the AST graph, and records precise_fallback.
-                             AI worktree directories (.claude, .cursor, .agents) and
-                             files/directories listed in .gitignore are automatically skipped.
-  stale                      Check if graph.json is older than Go source files (shows newest source time/file).
+                             Inactive build-constrained files, cmd/go wildcard-excluded
+                             directories, generated sources, go.mod ignore paths, AI
+                             worktrees, and Git-ignored paths are automatically skipped.
+  stale                      Check selected files, build context, and modification times.
                              Agents should run this before structural analysis.
   stats                      Compact index health summary: schema version, build
                              timestamp, and counts of packages, files, symbols,
@@ -2107,15 +2142,21 @@ func runStale() int {
 	}
 	sr := search.Stale(g, graphRoot(g))
 	if jsonMode {
-		return PrintJSON(okEnvelope("stale", "", sr, len(sr.ChangedFiles)))
+		return PrintJSON(okEnvelope("stale", "", sr, sr.ChangeCount()))
 	}
 	if !sr.IsStale {
 		fmt.Printf("Graph is up to date (generated: %s).\n", sr.GraphAge)
 		return 0
 	}
-	fmt.Printf("Graph is STALE (generated: %s). %d file(s) changed:\n", sr.GraphAge, len(sr.ChangedFiles))
-	for _, f := range sr.ChangedFiles {
-		fmt.Printf("  %s\n", f)
+	fmt.Printf("Graph is STALE (generated: %s).\n", sr.GraphAge)
+	if sr.BuildContextChanged {
+		fmt.Println("  effective Go build context changed")
+	}
+	if len(sr.ChangedFiles) > 0 {
+		fmt.Printf("  %d selected file(s) changed:\n", len(sr.ChangedFiles))
+		for _, f := range sr.ChangedFiles {
+			fmt.Printf("    %s\n", f)
+		}
 	}
 	fmt.Println("Run `gograph build .` to refresh.")
 	return 0

--- a/internal/cli/gate.go
+++ b/internal/cli/gate.go
@@ -93,7 +93,7 @@ func runGate(args []string) int {
 	root = graphRoot(g)
 	sr := search.Stale(g, root)
 	if sr.IsStale {
-		fmt.Fprintf(os.Stderr, "error: graph is stale compared to %d source file(s); refusing to evaluate outdated data.\n", len(sr.ChangedFiles))
+		fmt.Fprintf(os.Stderr, "error: graph is stale due to %d freshness change(s); refusing to evaluate outdated data.\n", sr.ChangeCount())
 		fmt.Fprintln(os.Stderr, "Run 'gograph build .' and retry.")
 		return 1
 	}

--- a/internal/cli/mcp_refresh_test.go
+++ b/internal/cli/mcp_refresh_test.go
@@ -148,6 +148,57 @@ func Purge(store Store) error { return store.Delete("key") }
 	}
 }
 
+func TestGraphRefresherRebuildsWhenIndexedFileBecomesInactive(t *testing.T) {
+	setDeterministicBuildEnvironment(t, "")
+	root := t.TempDir()
+	writeBuildContextFixture(t, root, "go.mod", "module example.com/inactive-refresh\n\ngo 1.26\n")
+	writeBuildContextFixture(t, root, "keep.go", "package refresh\nfunc KeepAfterRefresh() {}\n")
+	toggledPath := writeBuildContextFixture(t, root, "toggled.go", "package refresh\nfunc RemovedAfterConstraint() {}\n")
+
+	initial, err := buildPreciseGraph(root)
+	if err != nil {
+		skipCoverageCacheFallback(t, initial)
+		t.Fatal(err)
+	}
+	preciseBuilds := 0
+	refresh := graphRefresher(
+		initial,
+		root,
+		func(string) (*graph.Graph, error) { t.Fatal("unexpected AST build"); return nil, nil },
+		func(root string) (*graph.Graph, error) {
+			preciseBuilds++
+			return buildPreciseGraph(root)
+		},
+	)
+
+	if err := os.WriteFile(toggledPath, []byte("//go:build ignore\n\npackage refresh\nfunc RemovedAfterConstraint() {}\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	older := initial.GeneratedAt.Add(-time.Minute)
+	if err := os.Chtimes(toggledPath, older, older); err != nil {
+		t.Fatal(err)
+	}
+
+	refreshed, err := refresh()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if preciseBuilds != 1 || refreshed.Build.EffectivePrecision() != graph.PrecisionPrecise {
+		t.Fatalf("active-to-inactive change did not rebuild precisely once: builds=%d precision=%s", preciseBuilds, refreshed.Build.EffectivePrecision())
+	}
+	for _, symbol := range refreshed.Symbols {
+		if symbol.Name == "RemovedAfterConstraint" {
+			t.Fatalf("inactive symbol remained in refreshed graph: %+v", symbol)
+		}
+	}
+	if _, err := refresh(); err != nil {
+		t.Fatal(err)
+	}
+	if preciseBuilds != 1 {
+		t.Fatalf("stable refreshed graph rebuilt again: builds=%d", preciseBuilds)
+	}
+}
+
 func TestGraphRefresherRetriesRequestedPrecisionAfterFallback(t *testing.T) {
 	root := t.TempDir()
 	source := filepath.Join(root, "main.go")

--- a/internal/cli/stale_json_test.go
+++ b/internal/cli/stale_json_test.go
@@ -1,0 +1,82 @@
+package cli
+
+import (
+	"encoding/json"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/ozgurcd/gograph/internal/graph"
+	"github.com/ozgurcd/gograph/internal/search"
+)
+
+func TestRunStaleJSONContextOnlyUsesNonEmptyEnvelope(t *testing.T) {
+	setDeterministicBuildEnvironment(t, "")
+	root := t.TempDir()
+	writeBuildContextFixture(t, root, "active.go", "package fixture\n")
+	if err := os.MkdirAll(filepath.Join(root, outputDir), 0o750); err != nil {
+		t.Fatal(err)
+	}
+	g := &graph.Graph{
+		Version:     graph.Version,
+		Root:        root,
+		GeneratedAt: time.Now().Add(time.Hour),
+		Files:       []graph.FileNode{{Path: "active.go"}},
+		Build:       &graph.BuildMetadata{BuildContextFingerprint: "different-context"},
+	}
+	if err := writeJSON(filepath.Join(root, graphFile), g); err != nil {
+		t.Fatal(err)
+	}
+
+	originalWD, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(root); err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = os.Chdir(originalWD) }()
+
+	originalJSONMode := jsonMode
+	jsonMode = true
+	defer func() { jsonMode = originalJSONMode }()
+
+	originalStdout := os.Stdout
+	reader, writer, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	os.Stdout = writer
+	defer func() { os.Stdout = originalStdout }()
+
+	if code := runStale(); code != 0 {
+		t.Fatalf("runStale exit code = %d, want 0", code)
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatal(err)
+	}
+	output, err := io.ReadAll(reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var envelope struct {
+		Status  string             `json:"status"`
+		Count   int                `json:"count"`
+		Results search.StaleResult `json:"results"`
+	}
+	if err := json.Unmarshal(output, &envelope); err != nil {
+		t.Fatalf("decode stale JSON: %v\n%s", err, output)
+	}
+	if envelope.Status != "ok" || envelope.Count != 1 {
+		t.Fatalf("envelope = status:%q count:%d, want ok/1", envelope.Status, envelope.Count)
+	}
+	if !envelope.Results.IsStale || !envelope.Results.BuildContextChanged {
+		t.Fatalf("context-only stale result = %+v", envelope.Results)
+	}
+	if envelope.Results.ChangedFiles == nil || len(envelope.Results.ChangedFiles) != 0 {
+		t.Fatalf("changed_files = %#v, want []", envelope.Results.ChangedFiles)
+	}
+}

--- a/internal/graph/graph.go
+++ b/internal/graph/graph.go
@@ -48,12 +48,16 @@ type Graph struct {
 // are independent: a complete AST graph may have PrecisionFallback when the
 // optional type-checked enrichment could not run.
 type BuildMetadata struct {
-	ScannedFiles int            `json:"scanned_files"`
-	ParsedFiles  int            `json:"parsed_files"`
-	Complete     bool           `json:"complete"`
-	Precision    PrecisionMode  `json:"precision,omitempty"`
-	Failures     []BuildFailure `json:"failures,omitempty"`
-	Warnings     []string       `json:"warnings,omitempty"`
+	ScannedFiles int           `json:"scanned_files"`
+	ParsedFiles  int           `json:"parsed_files"`
+	Complete     bool          `json:"complete"`
+	Precision    PrecisionMode `json:"precision,omitempty"`
+	// BuildContextFingerprint hashes effective build and module-selection
+	// inputs, including nested module boundaries. The historical JSON field
+	// name is retained for schema-v2 compatibility.
+	BuildContextFingerprint string         `json:"build_context_fingerprint,omitempty"`
+	Failures                []BuildFailure `json:"failures,omitempty"`
+	Warnings                []string       `json:"warnings,omitempty"`
 }
 
 // PrecisionMode records both the requested analysis strength and its outcome.

--- a/internal/graph/graph_test.go
+++ b/internal/graph/graph_test.go
@@ -27,6 +27,9 @@ func TestLegacyV2GraphDefaultsToASTPrecisionAndLineOnlyCalls(t *testing.T) {
 	if g.Build.PreciseRequested() {
 		t.Fatal("legacy graph unexpectedly requests precise refresh")
 	}
+	if g.Build.BuildContextFingerprint != "" {
+		t.Fatalf("legacy graph fingerprint = %q, want empty", g.Build.BuildContextFingerprint)
+	}
 	if len(g.Calls) != 1 || g.Calls[0].Column != 0 || g.Calls[0].Synthetic {
 		t.Fatalf("legacy call provenance = %#v, want line-only ordinary call", g.Calls)
 	}
@@ -35,7 +38,7 @@ func TestLegacyV2GraphDefaultsToASTPrecisionAndLineOnlyCalls(t *testing.T) {
 func TestOptionalPrecisionAndCallProvenanceMetadataRemainAdditive(t *testing.T) {
 	g := Graph{
 		Version: Version,
-		Build:   &BuildMetadata{Complete: true, Precision: PrecisionPrecise},
+		Build:   &BuildMetadata{Complete: true, Precision: PrecisionPrecise, BuildContextFingerprint: "selection-v1"},
 		Calls: []CallEdge{{
 			CallerName: "Run",
 			CalleeRaw:  "Delete",
@@ -50,7 +53,7 @@ func TestOptionalPrecisionAndCallProvenanceMetadataRemainAdditive(t *testing.T) 
 		t.Fatal(err)
 	}
 	text := string(encoded)
-	for _, field := range []string{`"precision":"precise"`, `"column":21`, `"synthetic":true`} {
+	for _, field := range []string{`"precision":"precise"`, `"build_context_fingerprint":"selection-v1"`, `"column":21`, `"synthetic":true`} {
 		if !strings.Contains(text, field) {
 			t.Fatalf("encoded graph missing %s: %s", field, text)
 		}

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -201,7 +201,7 @@ func NewServer(
 			"prerequisite": "The MCP server loads .gograph/graph.json when present and auto-builds an in-memory graph when it is missing. Source-analysis tools check source freshness and newer persisted graphs per call, then rebuild after edits using the latest requested analysis mode; gograph_stale, gograph_changes without git_ref, and gograph_stats inspect the persisted index. Run `gograph build . --precise` for type-checked CHA/SSA enrichment; MCP adopts a newer precise graph and re-runs precision after source changes instead of silently downgrading to AST-only analysis. Session lifecycle tools write local telemetry, gograph_session_cleanup deletes stale logs, gograph_boundaries_create writes configuration, and gograph_wiki writes documentation. gograph_doc invokes the local Go toolchain and is annotated open-world because module resolution follows the user's Go environment.",
 			"tools": []map[string]string{
 				{"name": "gograph_capabilities", "purpose": "List all available tools and recommended workflows. No prerequisites."},
-				{"name": "gograph_stale", "purpose": "Check whether .gograph/graph.json is outdated vs source files. Run this first as a pre-flight check; if stale, run `gograph build .`."},
+				{"name": "gograph_stale", "purpose": "Check whether .gograph/graph.json is outdated vs selected source files or the effective Go build context. Run this first as a pre-flight check; if stale, run `gograph build .`."},
 				{"name": "gograph_session_create", "purpose": "Start a telemetry audit session for tracking agent compliance and tool success metrics."},
 				{"name": "gograph_session_end", "purpose": "End the active telemetry session cleanly and write end-of-session logs."},
 				{"name": "gograph_session_audit", "purpose": "Review and grade agent compliance (Plan rule, Review rule, Composability/Efficiency) and tool success rates."},
@@ -1738,7 +1738,7 @@ func initNewTools(
 
 	// Tool: gograph_stale
 	staleTool := mcp.NewTool("gograph_stale",
-		mcp.WithDescription("Check whether the persisted graph index loaded from .gograph/graph.json is older than current Go source files. This tool intentionally does not refresh first; when no artifact existed at server startup it compares against the startup auto-build fallback. Read-only; no side effects. WHEN TO USE: To decide whether CLI snapshot analysis or precise enrichment needs rebuilding. NOT TO USE: For module dependency freshness; for changed symbols (use gograph_changes). RETURNS: is_stale, graph_age, newest source metadata, and changed_files."),
+		mcp.WithDescription("Check whether the persisted graph index loaded from .gograph/graph.json differs from the current selected-file inventory, effective Go build context, or source modification times. This tool intentionally does not refresh first; when no artifact existed at server startup it compares against the startup auto-build fallback. Read-only; no side effects. WHEN TO USE: To decide whether CLI snapshot analysis or precise enrichment needs rebuilding. NOT TO USE: For module dependency freshness; for changed symbols (use gograph_changes). RETURNS: is_stale, graph_age, newest source metadata, changed_files, and build_context_changed."),
 	)
 	addTool(staleTool, func(_ context.Context, _ mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 		base := persistedGraph(indexedGraph)

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -144,6 +144,9 @@ func TestMCPStaleInspectsPersistedIndexWithoutRefresh(t *testing.T) {
 	if !strings.Contains(text, `"is_stale": true`) {
 		t.Fatalf("expected stale persisted index, got %s", text)
 	}
+	if !strings.Contains(text, `"changed_files": [`) || !strings.Contains(text, `"build_context_changed": false`) {
+		t.Fatalf("stale MCP contract omitted stable collection/context fields: %s", text)
+	}
 	if got := rebuilds.Load(); got != 0 {
 		t.Fatalf("gograph_stale rebuilt %d time(s), want 0", got)
 	}

--- a/internal/mcpbundle/bundle_test.go
+++ b/internal/mcpbundle/bundle_test.go
@@ -196,7 +196,10 @@ func TestBuildAllVerifyAllAndSmokeNative(t *testing.T) {
 	if testing.Short() {
 		t.Skip("cross-compiles all release targets")
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
+	// Cold CI runners cross-compile all six targets while other package tests
+	// may be doing the same work. Keep a hard bound without making 3 minutes a
+	// hidden performance requirement for release-bundle verification.
+	ctx, cancel := context.WithTimeout(context.Background(), 8*time.Minute)
 	defer cancel()
 	output := t.TempDir()
 	artifacts, err := BuildAll(ctx, repositoryRoot(t), output, testVersion)

--- a/internal/precise/precise.go
+++ b/internal/precise/precise.go
@@ -1,6 +1,7 @@
 package precise
 
 import (
+	"context"
 	"fmt"
 	"go/token"
 	"go/types"
@@ -8,6 +9,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/ozgurcd/gograph/internal/buildctx"
 	"github.com/ozgurcd/gograph/internal/graph"
 	"golang.org/x/tools/go/callgraph/cha"
 	"golang.org/x/tools/go/packages"
@@ -19,10 +21,22 @@ import (
 // It loads the project via go/packages, finds exact interface implementers,
 // and uses Class Hierarchy Analysis (CHA) to add precise dynamic dispatch call edges.
 func Enrich(absRoot string, g *graph.Graph) error {
+	config, err := buildctx.Resolve(context.Background(), absRoot)
+	if err != nil {
+		return err
+	}
+	return EnrichWithConfig(absRoot, g, config)
+}
+
+// EnrichWithConfig applies type-checked precision using the same effective Go
+// build configuration that selected files for the AST graph.
+func EnrichWithConfig(absRoot string, g *graph.Graph, config buildctx.Config) error {
 	cfg := &packages.Config{
 		Mode: packages.NeedName | packages.NeedFiles | packages.NeedCompiledGoFiles |
 			packages.NeedImports | packages.NeedDeps | packages.NeedTypes | packages.NeedTypesInfo | packages.NeedSyntax,
-		Dir: absRoot,
+		Dir:        absRoot,
+		Env:        config.Environment(),
+		BuildFlags: config.Flags(),
 	}
 
 	// Load all packages

--- a/internal/precise/precise.go
+++ b/internal/precise/precise.go
@@ -31,10 +31,16 @@ func Enrich(absRoot string, g *graph.Graph) error {
 // EnrichWithConfig applies type-checked precision using the same effective Go
 // build configuration that selected files for the AST graph.
 func EnrichWithConfig(absRoot string, g *graph.Graph, config buildctx.Config) error {
+	analysisRoot := absRoot
+	if config.ModuleRoot() != "" {
+		if resolved, err := filepath.EvalSymlinks(absRoot); err == nil {
+			analysisRoot = resolved
+		}
+	}
 	cfg := &packages.Config{
 		Mode: packages.NeedName | packages.NeedFiles | packages.NeedCompiledGoFiles |
 			packages.NeedImports | packages.NeedDeps | packages.NeedTypes | packages.NeedTypesInfo | packages.NeedSyntax,
-		Dir:        absRoot,
+		Dir:        analysisRoot,
 		Env:        config.Environment(),
 		BuildFlags: config.Flags(),
 	}
@@ -47,7 +53,7 @@ func EnrichWithConfig(absRoot string, g *graph.Graph, config buildctx.Config) er
 	if err := packageLoadError(initial); err != nil {
 		return err
 	}
-	if err := validatePackageCoverage(absRoot, initial, g); err != nil {
+	if err := validatePackageCoverage(analysisRoot, initial, g); err != nil {
 		return err
 	}
 
@@ -207,7 +213,7 @@ func EnrichWithConfig(absRoot string, g *graph.Graph, config buildctx.Config) er
 				// source method that actually executes.
 				if isSyntheticMethodWrapper(callerFn) {
 					calleePos := ssaFunctionOwnerPosition(prog.Fset, calleeFn)
-					if calleeSymID == "" || !pathWithinRoot(calleePos.Filename, absRoot) {
+					if calleeSymID == "" || !pathWithinRoot(calleePos.Filename, analysisRoot) {
 						continue
 					}
 					syntheticKey := callerSymID + "->" + calleeSymID
@@ -229,14 +235,14 @@ func EnrichWithConfig(absRoot string, g *graph.Graph, config buildctx.Config) er
 				}
 
 				pos := prog.Fset.Position(edge.Site.Pos())
-				if pos.Filename == "" || !pathWithinRoot(pos.Filename, absRoot) {
+				if pos.Filename == "" || !pathWithinRoot(pos.Filename, analysisRoot) {
 					continue
 				}
 				// Normalize to a repo-relative path so the dedup key matches the
 				// AST-sourced edge keys (which use relative paths). Without this,
 				// every AST call edge gets a CHA duplicate because the keys never
 				// match (absolute vs. relative path for the same call site).
-				relFile, relErr := filepath.Rel(absRoot, pos.Filename)
+				relFile, relErr := filepath.Rel(analysisRoot, pos.Filename)
 				if relErr != nil {
 					continue
 				}
@@ -256,7 +262,7 @@ func EnrichWithConfig(absRoot string, g *graph.Graph, config buildctx.Config) er
 					// target: collapsing this set into the first edge makes exact
 					// caller queries depend on nondeterministic map iteration order.
 					calleePos := ssaFunctionOwnerPosition(prog.Fset, calleeFn)
-					if calleeSymID == "" || !pathWithinRoot(calleePos.Filename, absRoot) {
+					if calleeSymID == "" || !pathWithinRoot(calleePos.Filename, analysisRoot) {
 						continue
 					}
 					// The exact source coordinate is the stable identity of the
@@ -323,7 +329,7 @@ func EnrichWithConfig(absRoot string, g *graph.Graph, config buildctx.Config) er
 				// excluding dependency implementations prevents an interface call
 				// such as err.Error() from expanding across the whole module cache.
 				calleePos := ssaFunctionOwnerPosition(prog.Fset, calleeFn)
-				if !pathWithinRoot(calleePos.Filename, absRoot) {
+				if !pathWithinRoot(calleePos.Filename, analysisRoot) {
 					continue
 				}
 				astEdgeIdx[key] = len(g.Calls)
@@ -351,7 +357,7 @@ func EnrichWithConfig(absRoot string, g *graph.Graph, config buildctx.Config) er
 	// stdlib allowlist) and attribute each call site to the field being
 	// addressed. Appends to g.Mutations alongside the AST-direct
 	// assignments that the parser already collected.
-	userMutators, directExtra := findMutatingMethods(prog, absRoot)
+	userMutators, directExtra := findMutatingMethods(prog, analysisRoot)
 
 	// 3a. Direct stores the AST parser missed. The parser only walks
 	// AssignStmt, which excludes IncDecStmt (`c.n++`), augmented
@@ -381,7 +387,7 @@ func EnrichWithConfig(absRoot string, g *graph.Graph, config buildctx.Config) er
 	}
 
 	// 3b. Indirect mutations through mutating-method calls.
-	indirect := collectIndirectMutations(prog, absRoot, userMutators)
+	indirect := collectIndirectMutations(prog, analysisRoot, userMutators)
 	g.Mutations = append(g.Mutations, indirect...)
 
 	return nil
@@ -443,6 +449,9 @@ func validatePackageCoverage(absRoot string, initial []*packages.Package, g *gra
 func absoluteSourcePath(root, path string) string {
 	if !filepath.IsAbs(path) {
 		path = filepath.Join(root, path)
+	}
+	if resolved, err := filepath.EvalSymlinks(path); err == nil {
+		path = resolved
 	}
 	return filepath.Clean(path)
 }

--- a/internal/scanner/build_context_test.go
+++ b/internal/scanner/build_context_test.go
@@ -2,11 +2,13 @@ package scanner_test
 
 import (
 	"go/build"
+	"os"
 	"path/filepath"
 	"reflect"
 	"sort"
 	"testing"
 
+	"github.com/ozgurcd/gograph/internal/buildctx"
 	"github.com/ozgurcd/gograph/internal/scanner"
 )
 
@@ -15,6 +17,8 @@ func TestWalkWithContextHonorsGoBuildSelection(t *testing.T) {
 	files := map[string]string{
 		"active.go":           "package fixture\n",
 		"ignored.go":          "//go:build ignore\n\npackage fixture\n",
+		"platform_amd64.go":   "package fixture\n",
+		"platform_arm64.go":   "package fixture\n",
 		"platform_linux.go":   "package fixture\n",
 		"platform_windows.go": "package fixture\n",
 		"feature.go":          "//go:build issue30_feature\n\npackage fixture\n",
@@ -49,7 +53,7 @@ func TestWalkWithContextHonorsGoBuildSelection(t *testing.T) {
 			name: "inactive constraints are excluded",
 			expected: []string{
 				"active.go", "feature.go", "feature_test.go", "legacy_feature.go",
-				"platform_linux.go", "release.go", "tool_tag.go",
+				"platform_amd64.go", "platform_linux.go", "release.go", "tool_tag.go",
 			},
 		},
 		{
@@ -59,7 +63,7 @@ func TestWalkWithContextHonorsGoBuildSelection(t *testing.T) {
 			},
 			expected: []string{
 				"active.go", "feature.go", "feature_test.go", "ignored.go", "legacy_feature.go",
-				"platform_linux.go", "release.go", "tool_tag.go",
+				"platform_amd64.go", "platform_linux.go", "release.go", "tool_tag.go",
 			},
 		},
 		{
@@ -69,7 +73,7 @@ func TestWalkWithContextHonorsGoBuildSelection(t *testing.T) {
 			},
 			expected: []string{
 				"active.go", "cgo.go", "feature.go", "feature_test.go", "legacy_feature.go",
-				"platform_linux.go", "release.go", "tool_tag.go",
+				"platform_amd64.go", "platform_linux.go", "release.go", "tool_tag.go",
 			},
 		},
 		{
@@ -77,7 +81,7 @@ func TestWalkWithContextHonorsGoBuildSelection(t *testing.T) {
 			configure: func(ctx *build.Context) {
 				ctx.BuildTags = nil
 			},
-			expected: []string{"active.go", "platform_linux.go", "release.go", "tool_tag.go"},
+			expected: []string{"active.go", "platform_amd64.go", "platform_linux.go", "release.go", "tool_tag.go"},
 		},
 	}
 
@@ -103,4 +107,199 @@ func TestWalkWithContextHonorsGoBuildSelection(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestWalkWithContextMatchesGoWildcardDirectoryRules(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "_repo")
+	mustWrite(t, filepath.Join(root, "root.go"), "package fixture\n")
+	mustWrite(t, filepath.Join(root, "normal", "keep.go"), "package normal\n")
+	mustWrite(t, filepath.Join(root, ".scratch", "hidden.go"), "package scratch\n")
+	mustWrite(t, filepath.Join(root, "_scratch", "hidden.go"), "package scratch\n")
+	mustWrite(t, filepath.Join(root, "testdata", "hidden.go"), "package testdata\n")
+
+	paths, errs := scanner.WalkWithContext(root, build.Default)
+	if len(errs) != 0 {
+		t.Fatalf("WalkWithContext errors: %v", errs)
+	}
+	got := relativePaths(t, root, paths)
+	want := []string{"normal/keep.go", "root.go"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("selected files = %v, want %v", got, want)
+	}
+}
+
+func TestWalkWithContextFollowsExplicitRootSymlink(t *testing.T) {
+	realRoot := filepath.Join(t.TempDir(), "real")
+	mustWrite(t, filepath.Join(realRoot, "root.go"), "package fixture\n")
+	linkRoot := filepath.Join(t.TempDir(), "linked-root")
+	if err := os.Symlink(realRoot, linkRoot); err != nil {
+		t.Skipf("create root symlink: %v", err)
+	}
+
+	paths, errs := scanner.WalkWithContext(linkRoot, build.Default)
+	if len(errs) != 0 {
+		t.Fatalf("WalkWithContext errors: %v", errs)
+	}
+	if got, want := relativePaths(t, linkRoot, paths), []string{"root.go"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("selected files = %v, want %v", got, want)
+	}
+}
+
+func TestWalkWithConfigHonorsModuleIgnoreDirectives(t *testing.T) {
+	root := t.TempDir()
+	mustWrite(t, filepath.Join(root, "go.mod"), `module example.com/ignore
+
+go 1.26
+
+ignore (
+	ignored
+	./anchored
+)
+`)
+	mustWrite(t, filepath.Join(root, "root.go"), "package fixture\n")
+	mustWrite(t, filepath.Join(root, "ignored", "noise.go"), "package ignored\n")
+	mustWrite(t, filepath.Join(root, "deep", "ignored", "noise.go"), "package ignored\n")
+	mustWrite(t, filepath.Join(root, "anchored", "noise.go"), "package anchored\n")
+	mustWrite(t, filepath.Join(root, "deep", "anchored", "keep.go"), "package anchored\n")
+	mustWrite(t, filepath.Join(root, "ignored2", "keep.go"), "package ignored2\n")
+
+	paths, errs := scanner.WalkWithConfig(root, moduleConfig(root, true))
+	if len(errs) != 0 {
+		t.Fatalf("WalkWithContext errors: %v", errs)
+	}
+	got := relativePaths(t, root, paths)
+	want := []string{"deep/anchored/keep.go", "ignored2/keep.go", "root.go"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("selected files = %v, want %v", got, want)
+	}
+}
+
+func TestWalkWithConfigHonorsParentModuleIgnoreFromSubdirectory(t *testing.T) {
+	moduleRoot := t.TempDir()
+	mustWrite(t, filepath.Join(moduleRoot, "go.mod"), "module example.com/root\n\ngo 1.26\n\nignore ignored\n")
+	scanRoot := filepath.Join(moduleRoot, "pkg")
+	mustWrite(t, filepath.Join(scanRoot, "keep.go"), "package pkg\n")
+	mustWrite(t, filepath.Join(scanRoot, "ignored", "noise.go"), "package ignored\n")
+
+	paths, errs := scanner.WalkWithConfig(scanRoot, moduleConfig(moduleRoot, true))
+	if len(errs) != 0 {
+		t.Fatalf("WalkWithConfig errors: %v", errs)
+	}
+	if got, want := relativePaths(t, scanRoot, paths), []string{"keep.go"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("selected files = %v, want %v", got, want)
+	}
+}
+
+func TestWalkWithConfigHonorsModuleIgnoreAtExplicitRoot(t *testing.T) {
+	moduleRoot := t.TempDir()
+	mustWrite(t, filepath.Join(moduleRoot, "go.mod"), "module example.com/root\n\ngo 1.26\n\nignore ./ignored\n")
+	scanRoot := filepath.Join(moduleRoot, "ignored")
+	mustWrite(t, filepath.Join(scanRoot, "noise.go"), "package ignored\n")
+
+	paths, errs := scanner.WalkWithConfig(scanRoot, moduleConfig(moduleRoot, true))
+	if len(errs) != 0 {
+		t.Fatalf("WalkWithConfig errors: %v", errs)
+	}
+	if len(paths) != 0 {
+		t.Fatalf("explicit ignored root selected files: %v", paths)
+	}
+}
+
+func TestWalkWithConfigAlignsCanonicalModuleRootWithLexicalScanPath(t *testing.T) {
+	base := t.TempDir()
+	realParent := filepath.Join(base, "real")
+	moduleRoot := filepath.Join(realParent, "module")
+	mustWrite(t, filepath.Join(moduleRoot, "go.mod"), "module example.com/root\n\ngo 1.26\n\nignore ignored\n")
+	mustWrite(t, filepath.Join(moduleRoot, "pkg", "keep.go"), "package pkg\n")
+	mustWrite(t, filepath.Join(moduleRoot, "pkg", "ignored", "noise.go"), "package ignored\n")
+	aliasParent := filepath.Join(base, "alias")
+	if err := os.Symlink(realParent, aliasParent); err != nil {
+		t.Skipf("create path alias: %v", err)
+	}
+	scanRoot := filepath.Join(aliasParent, "module", "pkg")
+
+	paths, errs := scanner.WalkWithConfig(scanRoot, moduleConfig(moduleRoot, true))
+	if len(errs) != 0 {
+		t.Fatalf("WalkWithConfig errors: %v", errs)
+	}
+	if got, want := relativePaths(t, scanRoot, paths), []string{"keep.go"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("selected files = %v, want %v", got, want)
+	}
+}
+
+func TestWalkWithConfigDoesNotApplyModuleIgnoreWhenModulesDisabled(t *testing.T) {
+	root := t.TempDir()
+	mustWrite(t, filepath.Join(root, "go.mod"), "module example.com/root\n\ngo 1.26\n\nignore ignored\n")
+	mustWrite(t, filepath.Join(root, "root.go"), "package root\n")
+	mustWrite(t, filepath.Join(root, "ignored", "noise.go"), "package ignored\n")
+
+	paths, errs := scanner.WalkWithConfig(root, moduleConfig(root, false))
+	if len(errs) != 0 {
+		t.Fatalf("WalkWithConfig errors: %v", errs)
+	}
+	want := []string{"ignored/noise.go", "root.go"}
+	if got := relativePaths(t, root, paths); !reflect.DeepEqual(got, want) {
+		t.Fatalf("selected files = %v, want %v", got, want)
+	}
+}
+
+func TestWalkWithConfigMalformedNestedModuleFailsOpen(t *testing.T) {
+	root := t.TempDir()
+	mustWrite(t, filepath.Join(root, "go.mod"), "module example.com/root\n\ngo 1.26\n")
+	mustWrite(t, filepath.Join(root, "root.go"), "package root\n")
+	mustWrite(t, filepath.Join(root, "nested", "go.mod"), "module\n")
+	mustWrite(t, filepath.Join(root, "nested", "child.go"), "package child\n")
+
+	paths, errs := scanner.WalkWithConfig(root, moduleConfig(root, true))
+	if len(errs) != 1 {
+		t.Fatalf("WalkWithContext errors = %v, want one malformed-module warning", errs)
+	}
+	got := relativePaths(t, root, paths)
+	want := []string{"nested/child.go", "root.go"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("selected files = %v, want %v", got, want)
+	}
+}
+
+func TestSelectionFingerprintTracksModuleIdentityAndBoundaries(t *testing.T) {
+	root := t.TempDir()
+	modPath := filepath.Join(root, "go.mod")
+	mustWrite(t, modPath, "module example.com/first\n\ngo 1.26\n")
+	mustWrite(t, filepath.Join(root, "root.go"), "package root\n")
+	mustWrite(t, filepath.Join(root, "nested", "child.go"), "package child\n")
+	config := moduleConfig(root, true)
+	_, first, errs := scanner.WalkWithConfigAndFingerprint(root, config)
+	if len(errs) != 0 {
+		t.Fatalf("initial walk errors: %v", errs)
+	}
+
+	mustWrite(t, modPath, "module example.com/second\n\ngo 1.26\n")
+	_, second, errs := scanner.WalkWithConfigAndFingerprint(root, config)
+	if len(errs) != 0 || second == first {
+		t.Fatalf("module identity fingerprint = %q (errors %v), want change from %q", second, errs, first)
+	}
+
+	mustWrite(t, filepath.Join(root, "nested", "go.mod"), "module example.com/nested\n\ngo 1.26\n")
+	_, third, errs := scanner.WalkWithConfigAndFingerprint(root, config)
+	if len(errs) != 0 || third == second {
+		t.Fatalf("module boundary fingerprint = %q (errors %v), want change from %q", third, errs, second)
+	}
+}
+
+func moduleConfig(moduleRoot string, enabled bool) buildctx.Config {
+	return buildctx.FromBuildContextWithModule(build.Default, nil, enabled, moduleRoot)
+}
+
+func relativePaths(t *testing.T, root string, paths []string) []string {
+	t.Helper()
+	relative := make([]string, 0, len(paths))
+	for _, path := range paths {
+		rel, err := filepath.Rel(root, path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		relative = append(relative, filepath.ToSlash(rel))
+	}
+	sort.Strings(relative)
+	return relative
 }

--- a/internal/scanner/build_context_test.go
+++ b/internal/scanner/build_context_test.go
@@ -1,0 +1,106 @@
+package scanner_test
+
+import (
+	"go/build"
+	"path/filepath"
+	"reflect"
+	"sort"
+	"testing"
+
+	"github.com/ozgurcd/gograph/internal/scanner"
+)
+
+func TestWalkWithContextHonorsGoBuildSelection(t *testing.T) {
+	root := t.TempDir()
+	files := map[string]string{
+		"active.go":           "package fixture\n",
+		"ignored.go":          "//go:build ignore\n\npackage fixture\n",
+		"platform_linux.go":   "package fixture\n",
+		"platform_windows.go": "package fixture\n",
+		"feature.go":          "//go:build issue30_feature\n\npackage fixture\n",
+		"other.go":            "//go:build issue30_other\n\npackage fixture\n",
+		"legacy_feature.go":   "// +build issue30_feature\n\npackage fixture\n",
+		"legacy_other.go":     "// +build issue30_other\n\npackage fixture\n",
+		"feature_test.go":     "//go:build issue30_feature\n\npackage fixture\nfunc TestFeature() {}\n",
+		"other_test.go":       "//go:build issue30_other\n\npackage fixture\nfunc TestOther() {}\n",
+		"cgo.go":              "package fixture\nimport \"C\"\n",
+		"release.go":          "//go:build go1.1\n\npackage fixture\n",
+		"tool_tag.go":         "//go:build issue30_tool\n\npackage fixture\n",
+		"_hidden.go":          "package fixture\n",
+	}
+	for name, content := range files {
+		mustWrite(t, filepath.Join(root, name), content)
+	}
+
+	base := build.Default
+	base.GOOS = "linux"
+	base.GOARCH = "amd64"
+	base.CgoEnabled = false
+	base.BuildTags = []string{"issue30_feature"}
+	base.ToolTags = []string{"issue30_tool"}
+	base.ReleaseTags = []string{"go1.1"}
+
+	cases := []struct {
+		name      string
+		configure func(*build.Context)
+		expected  []string
+	}{
+		{
+			name: "inactive constraints are excluded",
+			expected: []string{
+				"active.go", "feature.go", "feature_test.go", "legacy_feature.go",
+				"platform_linux.go", "release.go", "tool_tag.go",
+			},
+		},
+		{
+			name: "ignore can be activated explicitly",
+			configure: func(ctx *build.Context) {
+				ctx.BuildTags = append(ctx.BuildTags, "ignore")
+			},
+			expected: []string{
+				"active.go", "feature.go", "feature_test.go", "ignored.go", "legacy_feature.go",
+				"platform_linux.go", "release.go", "tool_tag.go",
+			},
+		},
+		{
+			name: "cgo import is active only when cgo is enabled",
+			configure: func(ctx *build.Context) {
+				ctx.CgoEnabled = true
+			},
+			expected: []string{
+				"active.go", "cgo.go", "feature.go", "feature_test.go", "legacy_feature.go",
+				"platform_linux.go", "release.go", "tool_tag.go",
+			},
+		},
+		{
+			name: "custom and legacy tags can be inactive",
+			configure: func(ctx *build.Context) {
+				ctx.BuildTags = nil
+			},
+			expected: []string{"active.go", "platform_linux.go", "release.go", "tool_tag.go"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := base
+			ctx.BuildTags = append([]string(nil), base.BuildTags...)
+			if tc.configure != nil {
+				tc.configure(&ctx)
+			}
+			paths, errs := scanner.WalkWithContext(root, ctx)
+			if len(errs) != 0 {
+				t.Fatalf("WalkWithContext errors: %v", errs)
+			}
+			got := make([]string, 0, len(paths))
+			for _, path := range paths {
+				got = append(got, filepath.Base(path))
+			}
+			sort.Strings(got)
+			sort.Strings(tc.expected)
+			if !reflect.DeepEqual(got, tc.expected) {
+				t.Fatalf("selected files = %v, want %v", got, tc.expected)
+			}
+		})
+	}
+}

--- a/internal/scanner/ignore.go
+++ b/internal/scanner/ignore.go
@@ -3,11 +3,18 @@ package scanner
 
 import (
 	"bufio"
+	"context"
+	"errors"
+	"fmt"
+	"go/build"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"sort"
 	"strings"
 	"sync"
+
+	"github.com/ozgurcd/gograph/internal/buildctx"
 )
 
 // ignoredDirs are directory names that are always skipped during the walk,
@@ -128,11 +135,28 @@ func (g *gitIgnoreChecker) isIgnored(absPath string) bool {
 // Generated files are excluded. An error slice is also returned for files that
 // could not be inspected (non-fatal).
 func Walk(root string) (paths []string, errs []error) {
+	config, configErr := buildctx.Resolve(context.Background(), root)
+	if configErr != nil {
+		config = buildctx.FromBuildContext(build.Default, os.Environ())
+	}
+	paths, errs = WalkWithContext(root, config.BuildContext())
+	if configErr != nil {
+		errs = append([]error{fmt.Errorf("using default Go build context: %w", configErr)}, errs...)
+	}
+	return paths, errs
+}
+
+// WalkWithContext traverses root and applies the supplied Go build context to
+// every candidate directory. ImportDir is intentionally used instead of
+// MatchFile: in addition to filename and header constraints, it classifies an
+// otherwise-unconstrained import "C" file as inactive when cgo is disabled.
+func WalkWithContext(root string, buildContext build.Context) (paths []string, errs []error) {
 	absRoot, err := filepath.Abs(root)
 	if err != nil {
 		absRoot = root
 	}
 	gitIgnore := newGitIgnoreChecker(absRoot)
+	candidatesByDir := make(map[string][]string)
 
 	err = filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
@@ -167,12 +191,50 @@ func Walk(root string) (paths []string, errs []error) {
 			return nil
 		}
 		if !skip {
-			paths = append(paths, path)
+			dir := filepath.Dir(path)
+			candidatesByDir[dir] = append(candidatesByDir[dir], path)
 		}
 		return nil
 	})
 	if err != nil {
 		errs = append(errs, err)
+	}
+
+	dirs := make([]string, 0, len(candidatesByDir))
+	for dir := range candidatesByDir {
+		dirs = append(dirs, dir)
+	}
+	sort.Strings(dirs)
+	for _, dir := range dirs {
+		candidates := candidatesByDir[dir]
+		pkg, importErr := buildContext.ImportDir(dir, 0)
+		if pkg == nil {
+			// Without partial package metadata there is no trustworthy way to
+			// classify the directory. Preserve AST mode's historical fail-open
+			// behavior, but surface the selection failure as a warning.
+			paths = append(paths, candidates...)
+			if importErr != nil {
+				errs = append(errs, fmt.Errorf("evaluate Go build constraints in %s: %w", dir, importErr))
+			}
+			continue
+		}
+
+		active := make(map[string]struct{}, len(pkg.GoFiles)+len(pkg.CgoFiles)+len(pkg.TestGoFiles)+len(pkg.XTestGoFiles)+len(pkg.InvalidGoFiles))
+		for _, names := range [][]string{pkg.GoFiles, pkg.CgoFiles, pkg.TestGoFiles, pkg.XTestGoFiles, pkg.InvalidGoFiles} {
+			for _, name := range names {
+				active[name] = struct{}{}
+			}
+		}
+		for _, path := range candidates {
+			if _, ok := active[filepath.Base(path)]; ok {
+				paths = append(paths, path)
+			}
+		}
+
+		var noGoErr *build.NoGoError
+		if importErr != nil && !errors.As(importErr, &noGoErr) {
+			errs = append(errs, fmt.Errorf("evaluate Go build constraints in %s: %w", dir, importErr))
+		}
 	}
 	return paths, errs
 }

--- a/internal/scanner/ignore.go
+++ b/internal/scanner/ignore.go
@@ -17,7 +17,7 @@ import (
 	"github.com/ozgurcd/gograph/internal/buildctx"
 )
 
-// ignoredDirs are directory names that are always skipped during the walk,
+// ignoredDirs are directory names skipped below the explicit scan root,
 // regardless of .gitignore. This is a fast O(1) check that requires no I/O.
 var ignoredDirs = map[string]bool{
 	".git":         true,
@@ -46,6 +46,14 @@ var ignoredDirs = map[string]bool{
 // be skipped entirely.
 func ShouldIgnoreDir(base string) bool {
 	return ignoredDirs[base]
+}
+
+// shouldIgnoreGoWildcardDir reports directories cmd/go excludes while
+// expanding ./.... The caller must exempt the explicit scan root so a project
+// whose own basename starts with '.' or '_' remains analyzable.
+func shouldIgnoreGoWildcardDir(base string) bool {
+	return (strings.HasPrefix(base, ".") && base != "." && base != "..") ||
+		strings.HasPrefix(base, "_") || base == "testdata"
 }
 
 // ShouldIgnoreFile reports whether a file should be skipped before parsing.
@@ -126,8 +134,10 @@ func (g *gitIgnoreChecker) isIgnored(absPath string) bool {
 
 // Walk traverses root and returns paths of .go files that should be parsed.
 // It respects:
-//  1. The hardcoded ignoredDirs blocklist (always active, no I/O).
-//  2. The repository's .gitignore rules via `git check-ignore` — this
+//  1. The effective Go build and module context.
+//  2. cmd/go's package-directory and module-ignore rules.
+//  3. Generated-file and hardcoded directory exclusions.
+//  4. The repository's .gitignore rules via `git check-ignore` — this
 //     eliminates duplicates caused by AI agent worktrees (e.g. .claude/worktrees/
 //     or any other tool-managed copy of the project) that are listed in .gitignore
 //     but live inside the project directory.
@@ -135,15 +145,19 @@ func (g *gitIgnoreChecker) isIgnored(absPath string) bool {
 // Generated files are excluded. An error slice is also returned for files that
 // could not be inspected (non-fatal).
 func Walk(root string) (paths []string, errs []error) {
-	config, configErr := buildctx.Resolve(context.Background(), root)
-	if configErr != nil {
-		config = buildctx.FromBuildContext(build.Default, os.Environ())
-	}
-	paths, errs = WalkWithContext(root, config.BuildContext())
+	paths, _, errs = WalkWithFingerprint(root)
+	return paths, errs
+}
+
+// WalkWithFingerprint returns the active source files and the fingerprint of
+// the effective build context used to select them.
+func WalkWithFingerprint(root string) (paths []string, fingerprint string, errs []error) {
+	config, configErr := buildctx.ResolveOrDefault(context.Background(), root)
+	paths, fingerprint, errs = WalkWithConfigAndFingerprint(root, config)
 	if configErr != nil {
 		errs = append([]error{fmt.Errorf("using default Go build context: %w", configErr)}, errs...)
 	}
-	return paths, errs
+	return paths, fingerprint, errs
 }
 
 // WalkWithContext traverses root and applies the supplied Go build context to
@@ -151,29 +165,62 @@ func Walk(root string) (paths []string, errs []error) {
 // MatchFile: in addition to filename and header constraints, it classifies an
 // otherwise-unconstrained import "C" file as inactive when cgo is disabled.
 func WalkWithContext(root string, buildContext build.Context) (paths []string, errs []error) {
+	return WalkWithConfig(root, buildctx.FromBuildContext(buildContext, nil))
+}
+
+// WalkWithConfig traverses root using one explicit source of file-selection
+// truth, including both the Go build context and module-mode state.
+func WalkWithConfig(root string, config buildctx.Config) (paths []string, errs []error) {
+	paths, _, errs = WalkWithConfigAndFingerprint(root, config)
+	return paths, errs
+}
+
+// WalkWithConfigAndFingerprint also returns a fingerprint of every effective
+// source-selection input observed during the walk, including nested module
+// boundaries and ignore directives.
+func WalkWithConfigAndFingerprint(root string, config buildctx.Config) (paths []string, fingerprint string, errs []error) {
 	absRoot, err := filepath.Abs(root)
 	if err != nil {
 		absRoot = root
 	}
+	buildContext := config.BuildContext()
 	gitIgnore := newGitIgnoreChecker(absRoot)
+	moduleIgnores, moduleErr := newModuleIgnoreTracker(config.ModulesEnabled(), config.ModuleRoot(), absRoot)
+	if moduleErr != nil {
+		errs = append(errs, moduleErr)
+	}
 	candidatesByDir := make(map[string][]string)
 
-	err = filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+	walkRoot := root
+	if rootInfo, lstatErr := os.Lstat(root); lstatErr == nil && rootInfo.Mode()&os.ModeSymlink != 0 {
+		if targetInfo, statErr := os.Stat(root); statErr == nil && targetInfo.IsDir() {
+			walkRoot = filepath.Clean(root) + string(filepath.Separator)
+		}
+	}
+	err = filepath.Walk(walkRoot, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
 			errs = append(errs, err)
 			return nil // keep walking
 		}
 		if info.IsDir() {
+			absPath, aerr := filepath.Abs(path)
+			isRoot := aerr == nil && filepath.Clean(absPath) == filepath.Clean(absRoot)
 			// Fast blocklist check (no subprocess).
-			if ShouldIgnoreDir(info.Name()) {
+			if !isRoot && (ShouldIgnoreDir(info.Name()) || shouldIgnoreGoWildcardDir(info.Name())) {
 				return filepath.SkipDir
 			}
 			// Gitignore check for directories: if the directory itself is
 			// gitignored skip the whole subtree with one syscall instead of
 			// checking every file inside it individually. This is what catches
 			// `.claude/worktrees/agent-*/` and similar AI agent scratch trees.
-			absPath, aerr := filepath.Abs(path)
 			if aerr == nil && gitIgnore.isIgnored(absPath) {
+				return filepath.SkipDir
+			}
+			skipModuleDir, moduleErr := moduleIgnores.enterDir(path)
+			if moduleErr != nil {
+				errs = append(errs, moduleErr)
+			}
+			if skipModuleDir {
 				return filepath.SkipDir
 			}
 			return nil
@@ -236,5 +283,5 @@ func WalkWithContext(root string, buildContext build.Context) (paths []string, e
 			errs = append(errs, fmt.Errorf("evaluate Go build constraints in %s: %w", dir, importErr))
 		}
 	}
-	return paths, errs
+	return paths, moduleIgnores.selectionFingerprint(config.Fingerprint()), errs
 }

--- a/internal/scanner/module_ignore.go
+++ b/internal/scanner/module_ignore.go
@@ -1,0 +1,270 @@
+package scanner
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"golang.org/x/mod/modfile"
+)
+
+// moduleIgnoreTracker mirrors the directory-pruning semantics used by
+// cmd/go when it expands ./... while still allowing nested modules to be
+// scanned so precise coverage can report that boundary explicitly.
+type moduleIgnoreTracker struct {
+	enabled bool
+	scopes  []moduleIgnoreScope
+}
+
+type moduleIgnoreScope struct {
+	root          string
+	canonicalRoot string
+	patterns      ignorePatterns
+	state         string
+	module        string
+}
+
+type ignorePatterns struct {
+	relative []string
+	anywhere []string
+}
+
+func newModuleIgnoreTracker(enabled bool, moduleRoot, scanRoot string) (*moduleIgnoreTracker, error) {
+	tracker := &moduleIgnoreTracker{enabled: enabled}
+	if !enabled || moduleRoot == "" {
+		return tracker, nil
+	}
+	moduleRoot = alignModuleRoot(moduleRoot, scanRoot)
+	if err := tracker.addScope(moduleRoot); err != nil {
+		return tracker, err
+	}
+	return tracker, nil
+}
+
+// alignModuleRoot preserves the scan root's lexical path while matching the
+// canonical path returned by cmd/go. This matters on systems such as macOS,
+// where /var and /private/var name the same directory.
+func alignModuleRoot(moduleRoot, scanRoot string) string {
+	moduleInfo, err := os.Stat(moduleRoot)
+	if err != nil {
+		return moduleRoot
+	}
+	absScanRoot, err := filepath.Abs(scanRoot)
+	if err != nil {
+		return moduleRoot
+	}
+	for candidate := filepath.Clean(absScanRoot); ; candidate = filepath.Dir(candidate) {
+		if candidateInfo, statErr := os.Stat(candidate); statErr == nil && os.SameFile(moduleInfo, candidateInfo) {
+			return candidate
+		}
+		parent := filepath.Dir(candidate)
+		if parent == candidate {
+			return moduleRoot
+		}
+	}
+}
+
+func (t *moduleIgnoreTracker) enterDir(dir string) (bool, error) {
+	if !t.enabled {
+		return false, nil
+	}
+	absDir, err := filepath.Abs(dir)
+	if err != nil {
+		return false, fmt.Errorf("resolve module directory %s: %w", dir, err)
+	}
+	absDir = filepath.Clean(absDir)
+
+	if scope, rel := t.nearestScope(absDir); scope != nil {
+		if scope.patterns.shouldIgnore(rel) {
+			return true, nil
+		}
+	}
+	if t.hasScope(absDir) {
+		return false, nil
+	}
+
+	modPath := filepath.Join(absDir, "go.mod")
+	info, err := os.Stat(modPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		return false, fmt.Errorf("stat %s: %w", modPath, err)
+	}
+	if info.IsDir() {
+		return false, nil
+	}
+	return false, t.addScope(absDir)
+}
+
+func (t *moduleIgnoreTracker) addScope(root string) error {
+	absRoot, err := filepath.Abs(root)
+	if err != nil {
+		return fmt.Errorf("resolve module directory %s: %w", root, err)
+	}
+	absRoot = filepath.Clean(absRoot)
+	canonicalRoot := absRoot
+	if resolved, resolveErr := filepath.EvalSymlinks(absRoot); resolveErr == nil {
+		canonicalRoot = filepath.Clean(resolved)
+	}
+	if t.hasScope(absRoot) {
+		return nil
+	}
+	modPath := filepath.Join(absRoot, "go.mod")
+	data, err := os.ReadFile(modPath)
+	if err != nil {
+		t.scopes = append(t.scopes, moduleIgnoreScope{root: absRoot, canonicalRoot: canonicalRoot, state: "unreadable"})
+		return fmt.Errorf("read %s: %w", modPath, err)
+	}
+
+	parsed, parseErr := modfile.Parse(modPath, data, nil)
+	patterns := ignorePatterns{}
+	modulePath := ""
+	if parseErr == nil {
+		if parsed.Module != nil {
+			modulePath = parsed.Module.Mod.Path
+		}
+		values := make([]string, 0, len(parsed.Ignore))
+		for _, directive := range parsed.Ignore {
+			values = append(values, directive.Path)
+		}
+		patterns = newIgnorePatterns(values)
+	}
+	// A nested module starts a new scope even when its go.mod is malformed.
+	// Failing open preserves AST analysis without incorrectly inheriting a
+	// parent module's ignore directives below the module boundary.
+	state := "valid"
+	if parseErr != nil {
+		state = "malformed"
+	}
+	t.scopes = append(t.scopes, moduleIgnoreScope{root: absRoot, canonicalRoot: canonicalRoot, patterns: patterns, state: state, module: modulePath})
+	if parseErr != nil {
+		return fmt.Errorf("parse %s for ignore directives: %w", modPath, parseErr)
+	}
+	return nil
+}
+
+func (t *moduleIgnoreTracker) selectionFingerprint(buildContextFingerprint string) string {
+	type scopeFingerprint struct {
+		Root     string   `json:"root"`
+		State    string   `json:"state"`
+		Module   string   `json:"module"`
+		Relative []string `json:"relative"`
+		Anywhere []string `json:"anywhere"`
+	}
+	scopes := make([]scopeFingerprint, 0, len(t.scopes))
+	for _, scope := range t.scopes {
+		relative := append([]string(nil), scope.patterns.relative...)
+		anywhere := append([]string(nil), scope.patterns.anywhere...)
+		sort.Strings(relative)
+		sort.Strings(anywhere)
+		scopes = append(scopes, scopeFingerprint{
+			Root:     scope.root,
+			State:    scope.state,
+			Module:   scope.module,
+			Relative: relative,
+			Anywhere: anywhere,
+		})
+	}
+	sort.Slice(scopes, func(i, j int) bool { return scopes[i].Root < scopes[j].Root })
+	payload, err := json.Marshal(struct {
+		Version      int                `json:"version"`
+		BuildContext string             `json:"build_context"`
+		Scopes       []scopeFingerprint `json:"module_scopes"`
+	}{
+		Version:      1,
+		BuildContext: buildContextFingerprint,
+		Scopes:       scopes,
+	})
+	if err != nil {
+		return ""
+	}
+	sum := sha256.Sum256(payload)
+	return hex.EncodeToString(sum[:])
+}
+
+func (t *moduleIgnoreTracker) hasScope(root string) bool {
+	for index := range t.scopes {
+		if t.scopes[index].root == root {
+			return true
+		}
+	}
+	return false
+}
+
+func (t *moduleIgnoreTracker) nearestScope(dir string) (*moduleIgnoreScope, string) {
+	canonicalDir := ""
+	for index := len(t.scopes) - 1; index >= 0; index-- {
+		scope := &t.scopes[index]
+		if rel, ok := relativeWithin(scope.root, dir); ok {
+			return scope, rel
+		}
+		if canonicalDir == "" {
+			if resolved, err := filepath.EvalSymlinks(dir); err == nil {
+				canonicalDir = filepath.Clean(resolved)
+			}
+		}
+		if canonicalDir != "" {
+			if rel, ok := relativeWithin(scope.canonicalRoot, canonicalDir); ok {
+				return scope, rel
+			}
+		}
+	}
+	return nil, ""
+}
+
+func relativeWithin(root, path string) (string, bool) {
+	relative, err := filepath.Rel(root, path)
+	if err != nil || relative == ".." || strings.HasPrefix(relative, ".."+string(filepath.Separator)) {
+		return "", false
+	}
+	return relative, true
+}
+
+func newIgnorePatterns(values []string) ignorePatterns {
+	patterns := ignorePatterns{}
+	for _, value := range values {
+		value, relative := strings.CutPrefix(value, "./")
+		normalized := normalizeIgnorePath(value)
+		if relative {
+			patterns.relative = append(patterns.relative, normalized)
+		} else {
+			patterns.anywhere = append(patterns.anywhere, normalized)
+		}
+	}
+	return patterns
+}
+
+func (p ignorePatterns) shouldIgnore(dir string) bool {
+	if dir == "" || dir == "." {
+		return false
+	}
+	normalized := normalizeIgnorePath(dir)
+	for _, pattern := range p.relative {
+		if strings.HasPrefix(normalized, pattern) {
+			return true
+		}
+	}
+	for _, pattern := range p.anywhere {
+		if strings.Contains(normalized, pattern) {
+			return true
+		}
+	}
+	return false
+}
+
+func normalizeIgnorePath(path string) string {
+	path = filepath.ToSlash(path)
+	if !strings.HasPrefix(path, "/") {
+		path = "/" + path
+	}
+	if !strings.HasSuffix(path, "/") {
+		path += "/"
+	}
+	return path
+}

--- a/internal/search/advanced.go
+++ b/internal/search/advanced.go
@@ -409,11 +409,23 @@ func ReachableOrphans(g *graph.Graph) []Result {
 
 // StaleResult reports the freshness of graph.json relative to source files.
 type StaleResult struct {
-	IsStale           bool     `json:"is_stale"`
-	GraphAge          string   `json:"graph_age"`
-	NewestSourceMtime string   `json:"newest_source_mtime,omitempty"`
-	NewestSourceFile  string   `json:"newest_source_file,omitempty"`
-	ChangedFiles      []string `json:"changed_files,omitempty"`
+	IsStale             bool     `json:"is_stale"`
+	GraphAge            string   `json:"graph_age"`
+	NewestSourceMtime   string   `json:"newest_source_mtime,omitempty"`
+	NewestSourceFile    string   `json:"newest_source_file,omitempty"`
+	ChangedFiles        []string `json:"changed_files"`
+	BuildContextChanged bool     `json:"build_context_changed"`
+}
+
+// ChangeCount returns the number of independent stale signals represented by
+// the result. It keeps machine-readable envelopes non-empty for a context-only
+// transition while retaining one count per changed selected file.
+func (r StaleResult) ChangeCount() int {
+	count := len(r.ChangedFiles)
+	if r.BuildContextChanged {
+		count++
+	}
+	return count
 }
 
 // GodObjectCandidate is a struct that exceeded at least one threshold.
@@ -428,24 +440,30 @@ type GodObjectCandidate struct {
 	Score         int    `json:"score"`
 }
 
-// Stale compares graph.json's GeneratedAt timestamp with the mtime of every
-// .go file under root. Pass the absolute repository root path.
+// Stale compares graph.json's selected-file inventory, effective build
+// context, and GeneratedAt timestamp with the current repository state. Pass
+// the absolute repository root path.
 //
 // Returns:
-//   - is_stale:            true when any .go file is newer than the graph.
+//   - is_stale:            true when selected files or their build context differ.
 //   - graph_age:           UTC timestamp of the graph build.
 //   - newest_source_mtime: UTC mtime of the newest .go file found (populated
 //     regardless of staleness — useful for diagnosis).
 //   - newest_source_file:  repo-relative path of that newest file.
-//   - changed_files:       all .go files newer than the graph (stale case only).
+//   - changed_files:       files newer than the graph or added/removed from the
+//     active build selection (stale case only).
+//   - build_context_changed: true when source-selection inputs changed.
 func Stale(g *graph.Graph, root string) StaleResult {
 	graphTime := g.GeneratedAt
-	var staleFiles []string
+	staleFiles := make(map[string]struct{})
 	var newestMtime time.Time
 	var newestPath string
 
-	files, _ := scanner.Walk(root)
+	files, buildContextFingerprint, _ := scanner.WalkWithFingerprint(root)
+	currentFiles := make(map[string]struct{}, len(files))
 	for _, path := range files {
+		rel := graphFileRelative(root, path)
+		currentFiles[rel] = struct{}{}
 		info, err := os.Stat(path)
 		if err != nil {
 			continue
@@ -455,19 +473,46 @@ func Stale(g *graph.Graph, root string) StaleResult {
 			newestPath = path
 		}
 		if info.ModTime().After(graphTime) {
-			if rel, relErr := filepath.Rel(root, path); relErr == nil {
-				staleFiles = append(staleFiles, rel)
-			} else {
-				staleFiles = append(staleFiles, path)
+			staleFiles[rel] = struct{}{}
+		}
+	}
+
+	previousFiles := make(map[string]struct{})
+	for _, file := range g.Files {
+		previousFiles[graphFileRelative(root, file.Path)] = struct{}{}
+	}
+	if g.Build != nil {
+		for _, failure := range g.Build.Failures {
+			previousFiles[graphFileRelative(root, failure.File)] = struct{}{}
+		}
+	}
+	if len(previousFiles) > 0 {
+		for path := range previousFiles {
+			if _, ok := currentFiles[path]; !ok {
+				staleFiles[path] = struct{}{}
+			}
+		}
+		for path := range currentFiles {
+			if _, ok := previousFiles[path]; !ok {
+				staleFiles[path] = struct{}{}
 			}
 		}
 	}
-	sortStrings(staleFiles)
+
+	buildContextChanged := g.Build != nil &&
+		g.Build.BuildContextFingerprint != "" &&
+		g.Build.BuildContextFingerprint != buildContextFingerprint
+	changedFiles := make([]string, 0, len(staleFiles))
+	for path := range staleFiles {
+		changedFiles = append(changedFiles, path)
+	}
+	sortStrings(changedFiles)
 
 	sr := StaleResult{
-		IsStale:      len(staleFiles) > 0,
-		GraphAge:     graphTime.Format("2006-01-02 15:04:05 UTC"),
-		ChangedFiles: staleFiles,
+		IsStale:             len(changedFiles) > 0 || buildContextChanged,
+		GraphAge:            graphTime.Format("2006-01-02 15:04:05 UTC"),
+		ChangedFiles:        changedFiles,
+		BuildContextChanged: buildContextChanged,
 	}
 	if !newestMtime.IsZero() {
 		sr.NewestSourceMtime = newestMtime.UTC().Format("2006-01-02 15:04:05 UTC")

--- a/internal/search/stale_test.go
+++ b/internal/search/stale_test.go
@@ -1,13 +1,16 @@
 package search_test
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/ozgurcd/gograph/internal/buildctx"
 	"github.com/ozgurcd/gograph/internal/graph"
+	"github.com/ozgurcd/gograph/internal/scanner"
 	"github.com/ozgurcd/gograph/internal/search"
 )
 
@@ -192,4 +195,112 @@ func TestStale_SkipsGeneratedFiles(t *testing.T) {
 	if sr.IsStale {
 		t.Fatalf("generated files must not make the graph stale: %v", sr.ChangedFiles)
 	}
+}
+
+func TestStale_ActiveFileBecomesInactive(t *testing.T) {
+	dir := t.TempDir()
+	config := testBuildConfig(t, dir)
+	graphTime := time.Now()
+	path := makeGoFile(t, dir, "active.go", graphTime.Add(-time.Minute))
+	fingerprint := testSelectionFingerprint(t, dir, config)
+	g := &graph.Graph{
+		GeneratedAt: graphTime,
+		Files:       []graph.FileNode{{Path: "active.go"}},
+		Build:       &graph.BuildMetadata{BuildContextFingerprint: fingerprint},
+	}
+	if err := os.WriteFile(path, []byte("//go:build ignore\n\npackage x\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chtimes(path, graphTime.Add(-time.Minute), graphTime.Add(-time.Minute)); err != nil {
+		t.Fatal(err)
+	}
+
+	sr := search.Stale(g, dir)
+	if !sr.IsStale || len(sr.ChangedFiles) != 1 || sr.ChangedFiles[0] != "active.go" {
+		t.Fatalf("active-to-inactive transition was not detected: %+v", sr)
+	}
+	if sr.BuildContextChanged {
+		t.Fatalf("file-selection transition incorrectly reported a context change: %+v", sr)
+	}
+}
+
+func TestStale_DeletedIndexedFile(t *testing.T) {
+	dir := t.TempDir()
+	config := testBuildConfig(t, dir)
+	graphTime := time.Now()
+	path := makeGoFile(t, dir, "deleted.go", graphTime.Add(-time.Minute))
+	fingerprint := testSelectionFingerprint(t, dir, config)
+	g := &graph.Graph{
+		GeneratedAt: graphTime,
+		Files:       []graph.FileNode{{Path: "deleted.go"}},
+		Build:       &graph.BuildMetadata{BuildContextFingerprint: fingerprint},
+	}
+	if err := os.Remove(path); err != nil {
+		t.Fatal(err)
+	}
+
+	sr := search.Stale(g, dir)
+	if !sr.IsStale || len(sr.ChangedFiles) != 1 || sr.ChangedFiles[0] != "deleted.go" {
+		t.Fatalf("deleted indexed file was not detected: %+v", sr)
+	}
+}
+
+func TestStale_BuildContextChangedWithoutMtimeChange(t *testing.T) {
+	dir := t.TempDir()
+	graphTime := time.Now()
+	makeGoFile(t, dir, "active.go", graphTime.Add(-time.Minute))
+	g := &graph.Graph{
+		GeneratedAt: graphTime,
+		Files:       []graph.FileNode{{Path: "active.go"}},
+		Build:       &graph.BuildMetadata{BuildContextFingerprint: "different-context"},
+	}
+
+	sr := search.Stale(g, dir)
+	if !sr.IsStale || !sr.BuildContextChanged || len(sr.ChangedFiles) != 0 {
+		t.Fatalf("context-only change was not reported distinctly: %+v", sr)
+	}
+	if sr.ChangeCount() != 1 {
+		t.Fatalf("context-only change count = %d, want 1", sr.ChangeCount())
+	}
+}
+
+func TestStale_ParseFailureRemainsInSelectedInventory(t *testing.T) {
+	dir := t.TempDir()
+	config := testBuildConfig(t, dir)
+	graphTime := time.Now()
+	makeGoFile(t, dir, "broken.go", graphTime.Add(-time.Minute))
+	fingerprint := testSelectionFingerprint(t, dir, config)
+	g := &graph.Graph{
+		GeneratedAt: graphTime,
+		Build: &graph.BuildMetadata{
+			BuildContextFingerprint: fingerprint,
+			Failures:                []graph.BuildFailure{{File: "broken.go", Error: "prior parse failure"}},
+		},
+	}
+
+	if sr := search.Stale(g, dir); sr.IsStale {
+		t.Fatalf("unchanged selected parse failure caused a stale loop: %+v", sr)
+	}
+}
+
+func testSelectionFingerprint(t *testing.T, root string, config buildctx.Config) string {
+	t.Helper()
+	_, fingerprint, errs := scanner.WalkWithConfigAndFingerprint(root, config)
+	if len(errs) != 0 {
+		t.Fatalf("walk test selection: %v", errs)
+	}
+	return fingerprint
+}
+
+func testBuildConfig(t *testing.T, root string) buildctx.Config {
+	t.Helper()
+	t.Setenv("GOENV", "off")
+	t.Setenv("GOWORK", "off")
+	t.Setenv("GOTOOLCHAIN", "local")
+	t.Setenv("GOFLAGS", "")
+	config, err := buildctx.Resolve(context.Background(), root)
+	if err != nil {
+		t.Fatalf("resolve test build context: %v", err)
+	}
+	return config
 }

--- a/llm-wiki/log.md
+++ b/llm-wiki/log.md
@@ -276,3 +276,17 @@ Normalized the security-flow page link into the index's Schemas and Security sec
 - Scanner selection now uses go/build.Context.ImportDir; inactive constrained/platform/cgo files contribute no graph records, while active constrained tests and invalid files remain available to AST analysis.
 - Precise loading receives the same pinned environment and build tags; the coverage invariant and repository-wide fallback remain unchanged.
 - Regressions cover the ignored package-main tool, MCP plan/review/check, custom and legacy tags, platform files, cgo, tests, explicit ignore activation, and nested-module fallback.
+
+## [2026-07-18] maintenance | Harden build-context-aware file selection
+
+- Completed GitHub issue #30 with one cmd/go-resolved configuration shared by AST scanning and precise package loading.
+- Excluded inactive modern and legacy build constraints, GOOS/GOARCH and cgo files, generated sources, wildcard-excluded directories, Git-ignored paths, and Go 1.26 go.mod ignore paths while retaining active constrained tests.
+- Added selected-file and module-selection freshness fingerprints so MCP/CLI refresh detects additions, deletions, active/inactive transitions, custom-tag changes, nested-module boundaries, and module identity changes.
+- Preserved precise coverage reconciliation and repository-wide fallback for genuine package-loader gaps.
+- Aligned module/GOPATH symbol identity and canonical path handling across explicit-root symlinks, module-subdirectory symlinks, invocation PWD changes, and symlinked go.mod files.
+- Exact v1.5.2 reproduction indexed the ignored package-main tool and fell back; the patched build indexed only the active library, reached precise mode, and returned no main symbol.
+- Focused regressions, full tests, race checks, lint/static/security checks, coverage, fuzzing, precise self-review, and the release pipeline are the required publication evidence.
+
+## [2026-07-18] maintenance | Close build-context log formatting
+
+- Consumed the governed append's trailing blank line as this entry's separator; no project facts changed.

--- a/llm-wiki/log.md
+++ b/llm-wiki/log.md
@@ -269,3 +269,10 @@ Normalized the security-flow page link into the index's Schemas and Security sec
 - Merged PR #28 at `f2d8de75c6ba16d72ffbccad5657a19e7650fdd9`; the `Closes #27` trailer closed the reporter's issue and a follow-up comment thanked @serdardalgic.
 - Final PR CI run 29308791305 passed unit/E2E tests, race, vet, static analysis, vulnerability checks, all six MCPBs, native MCP smoke, and documentation.
 - Corrected ordinary CI to verify candidate MCPBs against ephemeral metadata rendered from those exact artifacts. Release-time `mcpb-verify`, committed `server.json`, byte comparisons, and immutable v1.5.1 hashes remain unchanged and fail closed.
+
+## 2026-07-15 — Build-context-aware file selection (issue #30)
+
+- Added a shared cmd/go-resolved build-context snapshot for GOENV/GOFLAGS tags, GOOS/GOARCH, cgo, compiler, tool tags, and release tags.
+- Scanner selection now uses go/build.Context.ImportDir; inactive constrained/platform/cgo files contribute no graph records, while active constrained tests and invalid files remain available to AST analysis.
+- Precise loading receives the same pinned environment and build tags; the coverage invariant and repository-wide fallback remain unchanged.
+- Regressions cover the ignored package-main tool, MCP plan/review/check, custom and legacy tags, platform files, cgo, tests, explicit ignore activation, and nested-module fallback.

--- a/llm-wiki/project.md
+++ b/llm-wiki/project.md
@@ -2,7 +2,7 @@
 title: Project Identity and Architecture
 type: project
 status: current
-updated: 2026-07-12
+updated: 2026-07-18
 sources:
   - SRC-20260614-gograph-legacy-project
 ---
@@ -21,6 +21,8 @@ The executable Go package is `github.com/ozgurcd/gograph/cmd/gograph`. First-run
 
 Default builds produce an AST graph and tolerate partial parsing when at least one Go file succeeds. `BuildMetadata.Precision` records `ast`, `precise`, or `precise_fallback`; this is independent of complete/partial AST build health. Precise builds attempt go/packages type loading plus CHA/SSA. Missing indexed production files or type/load errors retain the AST graph and record a visible fallback instead of claiming precise success. `gograph stats` and MCP stats expose both precision and build health. `gate` fails closed for stale source, but it does not currently reject a fresh graph whose build metadata is incomplete; CI workflows that require complete coverage must check build health explicitly.
 
+Scanner file selection and `go/packages` share one cmd/go-resolved build configuration: GOOS/GOARCH, cgo, compiler, user and GOFLAGS tags, tool tags, and release tags. Active constrained tests remain indexed; inactive constraints, generated files, cmd/go wildcard-excluded directories, go.mod ignore paths, and Git-ignored paths do not enter any graph records. The persisted selection fingerprint includes the selected source inventory plus build and module-selection state, so freshness checks detect tag/platform changes, module-boundary changes, active/inactive transitions, additions, and deletions.
+
 ## Precise call-graph representation
 
 A dynamic interface invocation is represented by one deterministic `CallEdge` per valid named in-repository CHA target. Parallel target edges retain the same source expression provenance: caller identity, raw selector, file, line, column, and return-use metadata. User-facing caller/callee results deduplicate that source expression, while depth traversal, impact, diagrams, reachability, and orphan analysis follow every target.
@@ -31,14 +33,14 @@ Interface-qualified caller queries such as `OIDCStateRepository.Delete` resolve 
 
 ## MCP refresh policy
 
-Source-analysis MCP tools check both source freshness and replacement of the persisted graph artifact. A later successfully decoded precise publication is adopted even when overlapping builds give it an earlier build-start `GeneratedAt`. A precise or precise-fallback session never adopts an AST-only downgrade, and source edits rebuild in the current requested mode. Precise refresh failure is returned visibly while retaining fallback metadata for diagnosis and retry.
+Source-analysis MCP tools check the effective selected-file inventory, build/module fingerprint, source modification times, and replacement of the persisted graph artifact. A later successfully decoded precise publication is adopted even when overlapping builds give it an earlier build-start `GeneratedAt`. A precise or precise-fallback session never adopts an AST-only downgrade, and source-selection or source-content changes rebuild in the current requested mode. Precise refresh failure is returned visibly while retaining fallback metadata for diagnosis and retry.
 
 ## Compatibility
 
-The graph schema remains version 2. Precision, call-column, and synthetic-forwarding fields are additive JSON fields. Current readers normalize missing legacy precision to AST-only and missing call metadata to ordinary line-only edges. Older v2 binaries can decode new files, but may count or display synthetic forwarding records as ordinary calls; current binaries are required for the new traversal and presentation semantics.
+The graph schema remains version 2. Precision, call-column, synthetic-forwarding, and build-context fingerprint fields are additive JSON fields. Current readers normalize missing legacy precision to AST-only and missing call metadata to ordinary line-only edges. Older v2 binaries can decode new files, but may count or display synthetic forwarding records as ordinary calls; current binaries are required for the new traversal, presentation, and build-selection freshness semantics.
 
 ## Static-analysis limits
 
-Precise dispatch uses conservative CHA, so it can include named implementations that are not instantiated in one runtime configuration. Reflection, `unsafe`, plugins, unresolved function values, test-only packages, unnamed concrete types, module-external implementations, active build tags, and incomplete package loading can still cause omissions. AST callback recovery filters known ordinary identifiers, but selector-valued arguments remain name-based and can create false call edges when a data field shares a name with a callable. Precise implementer edges use qualified IDs, while legacy ID-less graphs and the AST implementer fallback remain package-insensitive. Changed-route policy checks also normalize handler names and can conflate same-named handlers across packages or receiver types. Treat zero-result and heuristic/fallback results as evidence to cross-check, not proof. Flow analysis remains path-insensitive with up to 16 call-site frames and query-time sanitizer policy; findings are review leads, not proof.
+Precise dispatch uses conservative CHA, so it can include named implementations that are not instantiated in one runtime configuration. Reflection, `unsafe`, plugins, unresolved function values, test-only packages, unnamed concrete types, module-external implementations, and incomplete package loading can still cause omissions. AST callback recovery filters known ordinary identifiers, but selector-valued arguments remain name-based and can create false call edges when a data field shares a name with a callable. Precise implementer edges use qualified IDs, while legacy ID-less graphs and the AST implementer fallback remain package-insensitive. Changed-route policy checks also normalize handler names and can conflate same-named handlers across packages or receiver types. Treat zero-result and heuristic/fallback results as evidence to cross-check, not proof. Flow analysis remains path-insensitive with up to 16 call-site frames and query-time sanitizer policy; findings are review leads, not proof.
 
 Non-goals include other languages, model APIs, SaaS, remote telemetry, and target binary/test execution.


### PR DESCRIPTION
## Summary

- resolve one effective cmd/go build context and share it between AST scanning and precise package loading
- exclude inactive build-constrained, platform, cgo, generated, gitignored, wildcard-excluded, and go.mod-ignored files from every graph record
- track selected-file and module-selection freshness so MCP and CLI refresh when build context or module boundaries change
- preserve precise coverage reconciliation and align identities across module, GOPATH, and symlinked-root cases
- add deterministic issue, MCP, custom-tag, platform, cgo, legacy-tag, constrained-test, module-ignore, stale, and symlink regressions
- keep cold six-target MCPB fixture builds bounded at eight minutes after two CI runs hit the former three-minute test-only limit

## Verification

- make release-go-check
- make test
- make test-coverage (60.9% total)
- make test-fuzz
- focused MCPB tests passed with a fresh Go build cache
- patched self-build reached precision=precise for 139/139 files; review succeeded; check reported 0 errors
- exact v1.5.2 fixture reproduced precise_fallback and leaked main; patched fixture reached precise and returned no main symbol
- independent blocker reviews found no remaining correctness, API, performance, portability, security, or stale-refresh blocker

Closes #30